### PR TITLE
Update courier to push correctly formatted bundle

### DIFF
--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -11,6 +11,7 @@ import yaml
 from operatorcourier.build import BuildCmd
 from operatorcourier.validate import ValidateCmd
 from operatorcourier.push import PushCmd
+from operatorcourier.format import format_bundle
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,9 @@ def build_and_verify(source_dir=None, yamls=None):
     if not valid:
         bundle = None
         logger.error("Bundle failed validation.")
-
+    else:
+        bundle = format_bundle(bundle)
+    
     return bundle
 
 def build_verify_and_push(namespace, repository, revision, token, source_dir=None, yamls=None):

--- a/operatorcourier/format.py
+++ b/operatorcourier/format.py
@@ -1,0 +1,86 @@
+import yaml
+from operatorcourier.build import BuildCmd
+
+class _literal(str): pass
+
+def _literal_presenter(dumper, data):
+    return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
+
+def _get_empty_formatted_bundle():
+    return dict(
+        data = dict(
+            customResourceDefinitions = '',
+            clusterServiceVersions = '',
+            packages = '',
+        )
+    )
+
+def format_bundle(bundle):
+    """
+    Converts a bundle object into a push-ready bundle by changing list values of 'customResourceDefinitions', 'clusterServiceVersions', and 'packages' into stringified yaml literals.
+    This format is required by the Marketplace backend.
+    
+    :param bundle: A bundle object
+    """
+
+    formattedBundle = _get_empty_formatted_bundle()
+
+    yaml.add_representer(_literal, _literal_presenter)
+
+    if 'data' in bundle:
+        # Format data fields as string literals to match backend expected format
+        if 'customResourceDefinitions' in bundle['data']:
+            if len(bundle['data']['customResourceDefinitions']) > 0:
+                formattedBundle['data']['customResourceDefinitions'] = _literal(yaml.dump(bundle['data']['customResourceDefinitions'], default_flow_style=False))
+
+        if 'clusterServiceVersions' in bundle['data']:
+            # Format description and alm-examples
+            clusterServiceVersions = []
+            for csv in bundle['data']['clusterServiceVersions']:
+                if 'metadata' in csv:
+                    if 'annotations' in csv['metadata']:
+                        if 'alm-examples' in csv['metadata']['annotations']:
+                            csv['metadata']['annotations']['alm-examples'] = _literal(csv['metadata']['annotations']['alm-examples'])
+                
+                if 'spec' in csv:
+                    if 'description' in csv['spec']:
+                        csv['spec']['description'] = _literal(csv['spec']['description'])
+                
+                clusterServiceVersions.append(csv)
+            
+            if len(clusterServiceVersions) > 0:
+                formattedBundle['data']['clusterServiceVersions'] = _literal(yaml.dump(clusterServiceVersions, default_flow_style=False))
+
+        if 'packages' in bundle['data']:
+            if len(bundle['data']['packages']) > 0:
+                formattedBundle['data']['packages'] = _literal(yaml.dump(bundle['data']['packages'], default_flow_style=False))
+
+    return formattedBundle
+
+def unformat_bundle(formattedBundle):
+    """
+    Converts a push-ready bundle into a structured object by changing stringified yaml of 'customResourceDefinitions', 'clusterServiceVersions', and 'packages' into lists of objects.
+    Undoing the format helps simplify bundle validation.
+
+    :param formattedBundle: A push-ready bundle
+    """
+
+    bundle = BuildCmd()._get_empty_bundle()
+ 
+    if 'data' in formattedBundle:
+        if 'customResourceDefinitions' in formattedBundle['data']:
+            customResourceDefinitions = yaml.safe_load(formattedBundle['data']['customResourceDefinitions'])
+            if customResourceDefinitions and len(customResourceDefinitions) > 0:
+                bundle['data']['customResourceDefinitions'] = customResourceDefinitions
+        
+        if 'clusterServiceVersions' in formattedBundle['data']:
+            clusterServiceVersions = yaml.safe_load(formattedBundle['data']['clusterServiceVersions'])
+            if clusterServiceVersions and len(clusterServiceVersions) > 0:
+                bundle['data']['clusterServiceVersions'] = clusterServiceVersions
+
+        if 'packages' in formattedBundle['data']:
+            packages = yaml.safe_load(formattedBundle['data']['packages'])
+            if packages and len(packages) > 0:
+                bundle['data']['packages'] = packages
+
+    return bundle

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ from unittest import TestCase
 import pytest
 import yaml
 from operatorcourier import api
+from operatorcourier.format import unformat_bundle
 
 @pytest.mark.parametrize('directory,expected', [
 ("tests/test_files/bundles/api/bundle1", "tests/test_files/bundles/api/bundle1/results/bundle.yaml"),
@@ -11,7 +12,7 @@ def test_make_bundle(directory, expected):
 
     with open(expected, "r") as expected_file:
         expected_bundle = yaml.safe_load(expected_file)
-        assert bundle == expected_bundle
+        assert unformat_bundle(bundle) == unformat_bundle(expected_bundle)
 
 @pytest.mark.parametrize('yaml_files,expected', [
 (["tests/test_files/bundles/api/bundle1/crd.yml",
@@ -29,4 +30,4 @@ def test_make_bundle_with_yaml_list(yaml_files, expected):
 
     with open(expected, "r") as expected_file:
         expected_bundle = yaml.safe_load(expected_file)
-        assert bundle == expected_bundle
+        assert unformat_bundle(bundle) == unformat_bundle(expected_bundle)

--- a/tests/test_files/bundles/api/bundle1/results/bundle.yaml
+++ b/tests/test_files/bundles/api/bundle1/results/bundle.yaml
@@ -1,188 +1,187 @@
 data:
-  clusterServiceVersions:
-  - apiVersion: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    metadata:
-      name: marketplace-operator.v0.0.1
-      namespace: placeholder
-    spec:
-      customresourcedefinitions:
-        owned:
-        - description: Represents a CatalogSourceConfig object which is used to configure
-            a CatalogSource.
-          displayName: Catalog Source Config
-          kind: CatalogSourceConfig
-          name: catalogsourceconfigs.marketplace.redhat.com
-          specDescriptors:
-          - description: The namespace where the operators will be enabled.
-            displayName: Target Namespace
-            path: targetNamespace
-          - description: List of operator(s) which will be enabled in the target namespace
-            displayName: Packages
-            path: packages
-          statusDescriptors:
-          - description: Current status of the CatalogSourceConfig
-            displayName: Current Phase Name
-            path: currentPhase.phase.name
-          - description: Message associated with the current status
-            displayName: Current Phase Message
-            path: currentPhase.phase.message
-          version: v1alpha1
-      description: Marketplace is a gateway for users to consume off-cluster Operators
-        which will include Red Hat, ISV, optional OpenShift and community content.
-      displayName: marketplace-operator
-      install:
-        spec:
-          clusterPermissions:
-          - rules:
-            - apiGroups:
-              - marketplace.redhat.com
-              resources:
-              - '*'
-              verbs:
-              - '*'
-            - apiGroups:
-              - ''
-              resources:
-              - services
-              - configmaps
-              verbs:
-              - '*'
-            - apiGroups:
-              - operators.coreos.com
-              resources:
-              - catalogsources
-              verbs:
-              - '*'
-            serviceAccountName: marketplace-operator
-          deployments:
-          - name: marketplace-operator
-            spec:
-              replicas: 1
-              selector:
-                matchLabels:
-                  name: marketplace-operator
-              template:
-                metadata:
-                  labels:
+  clusterServiceVersions: |
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: marketplace-operator.v0.0.1
+        namespace: placeholder
+      spec:
+        customresourcedefinitions:
+          owned:
+          - description: Represents a CatalogSourceConfig object which is used to configure
+              a CatalogSource.
+            displayName: Catalog Source Config
+            kind: CatalogSourceConfig
+            name: catalogsourceconfigs.marketplace.redhat.com
+            specDescriptors:
+            - description: The namespace where the operators will be enabled.
+              displayName: Target Namespace
+              path: targetNamespace
+            - description: List of operator(s) which will be enabled in the target namespace
+              displayName: Packages
+              path: packages
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+        description: |-
+          Marketplace is a gateway for users to consume off-cluster Operators which will include Red Hat, ISV, optional OpenShift and community content.
+        displayName: marketplace-operator
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - marketplace.redhat.com
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              - apiGroups:
+                - ''
+                resources:
+                - services
+                - configmaps
+                verbs:
+                - '*'
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - catalogsources
+                verbs:
+                - '*'
+              serviceAccountName: marketplace-operator
+            deployments:
+            - name: marketplace-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
                     name: marketplace-operator
-                  name: marketplace-operator
-                spec:
-                  containers:
-                  - command:
-                    - marketplace-operator
-                    env:
-                    - name: WATCH_NAMESPACE
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.namespace
-                    - name: OPERATOR_NAME
-                      value: marketplace-operator
-                    image: quay.io/openshift/origin-operator-marketplace:latest
-                    imagePullPolicy: Always
-                    livenessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8080
+                template:
+                  metadata:
+                    labels:
+                      name: marketplace-operator
                     name: marketplace-operator
-                    ports:
-                    - containerPort: 60000
-                      name: metrics
-                    - containerPort: 8080
-                      name: healthz
-                    readinessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8080
-                  serviceAccountName: marketplace-operator
-        strategy: deployment
-      installModes:
-      - supported: true
-        type: OwnNamespace
-      - supported: true
-        type: SingleNamespace
-      - supported: false
-        type: MultiNamespace
-      - supported: true
-        type: AllNamespaces
-      keywords:
-      - marketplace
-      - catalog
-      - olm
-      - admin
-      labels:
-        name: marketplace-operator
-      links:
-      - name: Markplace Operator Source Code
-        url: https://github.com/operator-framework/operator-marketplace
-      maintainers:
-      - email: aos-marketplace@redhat.com
-        name: AOS Marketplace Team
-      maturity: alpha
-      provider:
-        name: Red Hat
-      selector:
-        matchLabels:
+                  spec:
+                    containers:
+                    - command:
+                      - marketplace-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: marketplace-operator
+                      image: quay.io/openshift/origin-operator-marketplace:latest
+                      imagePullPolicy: Always
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                      name: marketplace-operator
+                      ports:
+                      - containerPort: 60000
+                        name: metrics
+                      - containerPort: 8080
+                        name: healthz
+                      readinessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                    serviceAccountName: marketplace-operator
+          strategy: deployment
+        installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - marketplace
+        - catalog
+        - olm
+        - admin
+        labels:
           name: marketplace-operator
-      version: 0.0.1
-  customResourceDefinitions:
-  - apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        description: Represents a CatalogSourceConfig.
-        displayName: Catalog Source Config
-      name: catalogsourceconfigs.marketplace.redhat.com
-    spec:
-      additionalPrinterColumns:
-      - JSONPath: .spec.targetNamespace
-        description: The namespace where the operators will be enabled
-        name: TargetNamespace
-        type: string
-      - JSONPath: .spec.packages
-        description: List of operator(s) which will be enabled in the target namespace
-        name: Packages
-        type: string
-      - JSONPath: .status.currentPhase.phase.name
-        description: Current status of the CatalogSourceConfig
-        name: Status
-        type: string
-      - JSONPath: .status.currentPhase.phase.message
-        description: Message associated with the current status
-        name: Message
-        type: string
-      - JSONPath: .metadata.creationTimestamp
-        name: Age
-        type: date
-      group: marketplace.redhat.com
-      names:
-        kind: CatalogSourceConfig
-        listKind: CatalogSourceConfigList
-        plural: catalogsourceconfigs
-        shortNames:
-        - csc
-        singular: catalogsourceconfig
-      scope: Namespaced
-      validation:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: Spec for a CatalogSourceConfig
-              properties:
-                packages:
-                  description: Comma separated list of operator(s) without spaces
-                    which will be enabled in the target namespace
-                  type: string
-                targetNamespace:
-                  description: The namespace where the operators will be enabled
-                  type: string
-              required:
-              - targetNamespace
-              - packages
-              type: object
-      version: v1alpha1
-  packages:
-  - channels:
-    - currentCSV: marketplace-operator.v0.0.1
-      name: alpha
-    packageName: marketplace
+        links:
+        - name: Markplace Operator Source Code
+          url: https://github.com/operator-framework/operator-marketplace
+        maintainers:
+        - email: aos-marketplace@redhat.com
+          name: AOS Marketplace Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        selector:
+          matchLabels:
+            name: marketplace-operator
+        version: 0.0.1
+  customResourceDefinitions: |
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents a CatalogSourceConfig.
+          displayName: Catalog Source Config
+        name: catalogsourceconfigs.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.targetNamespace
+          description: The namespace where the operators will be enabled
+          name: TargetNamespace
+          type: string
+        - JSONPath: .spec.packages
+          description: List of operator(s) which will be enabled in the target namespace
+          name: Packages
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the CatalogSourceConfig
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: CatalogSourceConfig
+          listKind: CatalogSourceConfigList
+          plural: catalogsourceconfigs
+          shortNames:
+          - csc
+          singular: catalogsourceconfig
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for a CatalogSourceConfig
+                properties:
+                  packages:
+                    description: Comma separated list of operator(s) without spaces which will be enabled in the target namespace
+                    type: string
+                  targetNamespace:
+                    description: The namespace where the operators will be enabled
+                    type: string
+                required:
+                - targetNamespace
+                - packages
+                type: object
+        version: v1alpha1
+  packages: |
+    - channels:
+      - currentCSV: marketplace-operator.v0.0.1
+        name: alpha
+      packageName: marketplace

--- a/tests/test_files/bundles/verification/invalid.bundle.yaml
+++ b/tests/test_files/bundles/verification/invalid.bundle.yaml
@@ -1,296 +1,296 @@
 data:
-  clusterServiceVersions:
-  - apiVersion: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    metadata:
-      annotations:
-        alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
-        categories: openshift required
-        certified: 'true'
-        containerImage: quay.io/openshift/origin-operator-marketplace:latest
-        createdAt: 2019/11/15
-        description: An operator to run the OpenShift marketplace
-        healthIndex: B
-        repository: https://github.com/operator-framework/operator-marketplace
-        support: Red Hat
-      name: marketplace-operator.v0.0.1
-      namespace: placeholder
-    spec:
-      customresourcedefinitions:
-        owned:
-        - description: Represents an OperatorSource.
-          displayName: Operator Source
-          kind: OperatorSource
-          name: operatorsources.marketplace.redhat.com
-          specDescriptors:
-          - description: The type of the operator source.
-            displayName: Type
-            path: type
-          - description: Points to the remote app registry server from where operator
-              manifests can be fetched.
-            displayName: Endpoint
-            path: endpoint
-          - description: 'The namespace in app registry.
+  clusterServiceVersions: |
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+          categories: openshift required
+          certified: 'true'
+          containerImage: quay.io/openshift/origin-operator-marketplace:latest
+          createdAt: 2019/11/15
+          description: An operator to run the OpenShift marketplace
+          healthIndex: B
+          repository: https://github.com/operator-framework/operator-marketplace
+          support: Red Hat
+        name: marketplace-operator.v0.0.1
+        namespace: placeholder
+      spec:
+        customresourcedefinitions:
+          owned:
+          - description: Represents an OperatorSource.
+            displayName: Operator Source
+            kind: OperatorSource
+            name: operatorsources.marketplace.redhat.com
+            specDescriptors:
+            - description: The type of the operator source.
+              displayName: Type
+              path: type
+            - description: Points to the remote app registry server from where operator
+                manifests can be fetched.
+              displayName: Endpoint
+              path: endpoint
+            - description: 'The namespace in app registry.
 
-              Only operator manifests under this namespace will be visible.
+                Only operator manifests under this namespace will be visible.
 
-              Please note that this is not a k8s namespace.'
-            displayName: Registry Namespace
-            path: registryNamespace
-          statusDescriptors:
-          - description: Current status of the CatalogSourceConfig
-            displayName: Current Phase Name
-            path: currentPhase.phase.name
-          - description: Message associated with the current status
-            displayName: Current Phase Message
-            path: currentPhase.phase.message
-          version: v1alpha1
-        - description: Represents a CatalogSourceConfig object which is used to configure
-            a CatalogSource.
-          displayName: Catalog Source Config
-          kind: CatalogSourceConfig
-          name: catalogsourceconfigs.marketplace.redhat.com
-          specDescriptors:
-          - description: The namespace where the operators will be enabled.
-            displayName: Target Namespace
-            path: targetNamespace
-          - description: List of operator(s) which will be enabled in the target namespace
-            displayName: Packages
-            path: packages
-          statusDescriptors:
-          - description: Current status of the CatalogSourceConfig
-            displayName: Current Phase Name
-            path: currentPhase.phase.name
-          - description: Message associated with the current status
-            displayName: Current Phase Message
-            path: currentPhase.phase.message
-          version: v1alpha1
-      description: Marketplace is a gateway for users to consume off-cluster Operators
-        which will include Red Hat, ISV, optional OpenShift and community content.
-      displayName: marketplace-operator
-      install:
-        spec:
-          clusterPermissions:
-          - rules:
-            - apiGroups:
-              - marketplace.redhat.com
-              resources:
-              - '*'
-              verbs:
-              - '*'
-            - apiGroups:
-              - ''
-              resources:
-              - services
-              - configmaps
-              verbs:
-              - '*'
-            - apiGroups:
-              - operators.coreos.com
-              resources:
-              - catalogsources
-              verbs:
-              - '*'
-            serviceAccountName: marketplace-operator
-          deployments:
-          - name: marketplace-operator
-            spec:
-              replicas: 1
-              selector:
-                matchLabels:
-                  name: marketplace-operator
-              template:
-                metadata:
-                  labels:
+                Please note that this is not a k8s namespace.'
+              displayName: Registry Namespace
+              path: registryNamespace
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+          - description: Represents a CatalogSourceConfig object which is used to configure
+              a CatalogSource.
+            displayName: Catalog Source Config
+            kind: CatalogSourceConfig
+            name: catalogsourceconfigs.marketplace.redhat.com
+            specDescriptors:
+            - description: The namespace where the operators will be enabled.
+              displayName: Target Namespace
+              path: targetNamespace
+            - description: List of operator(s) which will be enabled in the target namespace
+              displayName: Packages
+              path: packages
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+        description: Marketplace is a gateway for users to consume off-cluster Operators
+          which will include Red Hat, ISV, optional OpenShift and community content.
+        displayName: marketplace-operator
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - marketplace.redhat.com
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              - apiGroups:
+                - ''
+                resources:
+                - services
+                - configmaps
+                verbs:
+                - '*'
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - catalogsources
+                verbs:
+                - '*'
+              serviceAccountName: marketplace-operator
+            deployments:
+            - name: marketplace-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
                     name: marketplace-operator
-                  name: marketplace-operator
-                spec:
-                  containers:
-                  - command:
-                    - marketplace-operator
-                    env:
-                    - name: WATCH_NAMESPACE
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.namespace
-                    - name: OPERATOR_NAME
-                      value: marketplace-operator
-                    image: quay.io/openshift/origin-operator-marketplace:latest
-                    imagePullPolicy: Always
-                    livenessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8080
+                template:
+                  metadata:
+                    labels:
+                      name: marketplace-operator
                     name: marketplace-operator
-                    ports:
-                    - containerPort: 60000
-                      name: metrics
-                    - containerPort: 8080
-                      name: healthz
-                    readinessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8080
-                  serviceAccountName: marketplace-operator
-        strategy: deployment
-      installModes:
-      - supported: true
-        type: OwnNamespace
-      - supported: true
-        type: SingleNamespace
-      - supported: false
-        type: MultiNamespace
-      - supported: true
-        type: AllNamespaces
-      keywords:
-      - marketplace
-      - catalog
-      - olm
-      - admin
-      labels:
-        name: marketplace-operator
-      links:
-      - name: Markplace Operator Source Code
-        url: https://github.com/operator-framework/operator-marketplace
-      maintainers:
-      - email: aos-marketplace@redhat.com
-        name: AOS Marketplace Team
-      maturity: alpha
-      provider:
-        name: Red Hat
-      selector:
-        matchLabels:
+                  spec:
+                    containers:
+                    - command:
+                      - marketplace-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: marketplace-operator
+                      image: quay.io/openshift/origin-operator-marketplace:latest
+                      imagePullPolicy: Always
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                      name: marketplace-operator
+                      ports:
+                      - containerPort: 60000
+                        name: metrics
+                      - containerPort: 8080
+                        name: healthz
+                      readinessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                    serviceAccountName: marketplace-operator
+          strategy: deployment
+        installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - marketplace
+        - catalog
+        - olm
+        - admin
+        labels:
           name: marketplace-operator
-      version: 0.0.1
-  customResourceDefinitions:
-  - apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        description: Represents a CatalogSourceConfig.
-        displayName: Catalog Source Config
-      name: catalogsourceconfigs.marketplace.redhat.com
-    spec:
-      additionalPrinterColumns:
-      - JSONPath: .spec.targetNamespace
-        description: The namespace where the operators will be enabled
-        name: TargetNamespace
-        type: string
-      - JSONPath: .spec.packages
-        description: List of operator(s) which will be enabled in the target namespace
-        name: Packages
-        type: string
-      - JSONPath: .status.currentPhase.phase.name
-        description: Current status of the CatalogSourceConfig
-        name: Status
-        type: string
-      - JSONPath: .status.currentPhase.phase.message
-        description: Message associated with the current status
-        name: Message
-        type: string
-      - JSONPath: .metadata.creationTimestamp
-        name: Age
-        type: date
-      group: marketplace.redhat.com
-      names:
-        kind: CatalogSourceConfig
-        listKind: CatalogSourceConfigList
-        plural: catalogsourceconfigs
-        shortNames:
-        - csc
-        singular: catalogsourceconfig
-      scope: Namespaced
-      validation:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: Spec for a CatalogSourceConfig
-              properties:
-                packages:
-                  description: Comma separated list of operator(s) without spaces
-                    which will be enabled in the target namespace
-                  type: string
-                targetNamespace:
-                  description: The namespace where the operators will be enabled
-                  type: string
-              required:
-              - targetNamespace
-              - packages
-              type: object
-      version: v1alpha1
-  - apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        description: Represents an OperatorSource.
-        displayName: Operator Source
-      name: operatorsources.marketplace.redhat.com
-    spec:
-      additionalPrinterColumns:
-      - JSONPath: .spec.type
-        description: The type of the OperatorSource
-        name: Type
-        type: string
-      - JSONPath: .spec.endpoint
-        description: The endpoint of the OperatorSource
-        name: Endpoint
-        type: string
-      - JSONPath: .spec.registryNamespace
-        description: App registry namespace
-        name: Registry
-        type: string
-      - JSONPath: .spec.displayName
-        description: Display (pretty) name to indicate the OperatorSource's name
-        name: DisplayName
-        type: string
-      - JSONPath: .spec.publisher
-        description: Publisher of the OperatorSource
-        name: Publisher
-        type: string
-      - JSONPath: .status.currentPhase.phase.name
-        description: Current status of the OperatorSource
-        name: Status
-        type: string
-      - JSONPath: .status.currentPhase.phase.message
-        description: Message associated with the current status
-        name: Message
-        type: string
-      - JSONPath: .metadata.creationTimestamp
-        name: Age
-        type: date
-      group: marketplace.redhat.com
-      names:
-        kind: OperatorSource
-        listKind: OperatorSourceList
-        plural: operatorsources
-        shortNames:
-        - opsrc
-        singular: operatorsource
-      scope: Namespaced
-      validation:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: Spec for an OperatorSource.
-              properties:
-                endpoint:
-                  description: Points to the remote app registry server from where
-                    operator manifests can be fetched.
-                  type: string
-                registryNamespace:
-                  description: 'The namespace in app registry.
+        links:
+        - name: Markplace Operator Source Code
+          url: https://github.com/operator-framework/operator-marketplace
+        maintainers:
+        - email: aos-marketplace@redhat.com
+          name: AOS Marketplace Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        selector:
+          matchLabels:
+            name: marketplace-operator
+        version: 0.0.1
+  customResourceDefinitions: |
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents a CatalogSourceConfig.
+          displayName: Catalog Source Config
+        name: catalogsourceconfigs.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.targetNamespace
+          description: The namespace where the operators will be enabled
+          name: TargetNamespace
+          type: string
+        - JSONPath: .spec.packages
+          description: List of operator(s) which will be enabled in the target namespace
+          name: Packages
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the CatalogSourceConfig
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: CatalogSourceConfig
+          listKind: CatalogSourceConfigList
+          plural: catalogsourceconfigs
+          shortNames:
+          - csc
+          singular: catalogsourceconfig
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for a CatalogSourceConfig
+                properties:
+                  packages:
+                    description: Comma separated list of operator(s) without spaces
+                      which will be enabled in the target namespace
+                    type: string
+                  targetNamespace:
+                    description: The namespace where the operators will be enabled
+                    type: string
+                required:
+                - targetNamespace
+                - packages
+                type: object
+        version: v1alpha1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents an OperatorSource.
+          displayName: Operator Source
+        name: operatorsources.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.type
+          description: The type of the OperatorSource
+          name: Type
+          type: string
+        - JSONPath: .spec.endpoint
+          description: The endpoint of the OperatorSource
+          name: Endpoint
+          type: string
+        - JSONPath: .spec.registryNamespace
+          description: App registry namespace
+          name: Registry
+          type: string
+        - JSONPath: .spec.displayName
+          description: Display (pretty) name to indicate the OperatorSource's name
+          name: DisplayName
+          type: string
+        - JSONPath: .spec.publisher
+          description: Publisher of the OperatorSource
+          name: Publisher
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the OperatorSource
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: OperatorSource
+          listKind: OperatorSourceList
+          plural: operatorsources
+          shortNames:
+          - opsrc
+          singular: operatorsource
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for an OperatorSource.
+                properties:
+                  endpoint:
+                    description: Points to the remote app registry server from where
+                      operator manifests can be fetched.
+                    type: string
+                  registryNamespace:
+                    description: 'The namespace in app registry.
 
-                    Only operator manifests under this namespace will be visible.
+                      Only operator manifests under this namespace will be visible.
 
-                    Please note that this is not a k8s namespace.'
-                  type: string
-                type:
-                  description: The type of the OperatorSource
-                  pattern: appregistry
-                  type: string
-              required:
-              - type
-              - endpoint
-              - registryNamespace
-              type: object
-      version: v1alpha1
+                      Please note that this is not a k8s namespace.'
+                    type: string
+                  type:
+                    description: The type of the OperatorSource
+                    pattern: appregistry
+                    type: string
+                required:
+                - type
+                - endpoint
+                - registryNamespace
+                type: object
+        version: v1alpha1

--- a/tests/test_files/bundles/verification/nocrd.valid.bundle.yaml
+++ b/tests/test_files/bundles/verification/nocrd.valid.bundle.yaml
@@ -1,6 +1,6 @@
 data:
   customResourceDefinitions: |-
-  clusterServiceVersions:
+  clusterServiceVersions: |-
     - #! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
       #! parse-kind: ClusterServiceVersion
       apiVersion: operators.coreos.com/v1alpha1
@@ -387,7 +387,7 @@ data:
             deploymentName: svcat-apiserver
             containerPort: 5443
       
-  packages:
+  packages: |-
     - #! package-manifest: deploy/chart/catalog_resources/rh-operators/svcat.v0.1.34.clusterserviceversion.yaml
       packageName: svcat
       channels:

--- a/tests/test_files/bundles/verification/valid.bundle.yaml
+++ b/tests/test_files/bundles/verification/valid.bundle.yaml
@@ -1,301 +1,301 @@
 data:
-  clusterServiceVersions:
-  - apiVersion: operators.coreos.com/v1alpha1
-    kind: ClusterServiceVersion
-    metadata:
-      annotations:
-        alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
-        categories: openshift required
-        certified: 'true'
-        containerImage: quay.io/openshift/origin-operator-marketplace:latest
-        createdAt: 2019/11/15
-        description: An operator to run the OpenShift marketplace
-        healthIndex: B
-        repository: https://github.com/operator-framework/operator-marketplace
-        support: Red Hat
-      name: marketplace-operator.v0.0.1
-      namespace: placeholder
-    spec:
-      customresourcedefinitions:
-        owned:
-        - description: Represents an OperatorSource.
-          displayName: Operator Source
-          kind: OperatorSource
-          name: operatorsources.marketplace.redhat.com
-          specDescriptors:
-          - description: The type of the operator source.
-            displayName: Type
-            path: type
-          - description: Points to the remote app registry server from where operator
-              manifests can be fetched.
-            displayName: Endpoint
-            path: endpoint
-          - description: 'The namespace in app registry.
+  clusterServiceVersions: |
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+          categories: openshift required
+          certified: 'true'
+          containerImage: quay.io/openshift/origin-operator-marketplace:latest
+          createdAt: 2019/11/15
+          description: An operator to run the OpenShift marketplace
+          healthIndex: B
+          repository: https://github.com/operator-framework/operator-marketplace
+          support: Red Hat
+        name: marketplace-operator.v0.0.1
+        namespace: placeholder
+      spec:
+        customresourcedefinitions:
+          owned:
+          - description: Represents an OperatorSource.
+            displayName: Operator Source
+            kind: OperatorSource
+            name: operatorsources.marketplace.redhat.com
+            specDescriptors:
+            - description: The type of the operator source.
+              displayName: Type
+              path: type
+            - description: Points to the remote app registry server from where operator
+                manifests can be fetched.
+              displayName: Endpoint
+              path: endpoint
+            - description: 'The namespace in app registry.
 
-              Only operator manifests under this namespace will be visible.
+                Only operator manifests under this namespace will be visible.
 
-              Please note that this is not a k8s namespace.'
-            displayName: Registry Namespace
-            path: registryNamespace
-          statusDescriptors:
-          - description: Current status of the CatalogSourceConfig
-            displayName: Current Phase Name
-            path: currentPhase.phase.name
-          - description: Message associated with the current status
-            displayName: Current Phase Message
-            path: currentPhase.phase.message
-          version: v1alpha1
-        - description: Represents a CatalogSourceConfig object which is used to configure
-            a CatalogSource.
-          displayName: Catalog Source Config
-          kind: CatalogSourceConfig
-          name: catalogsourceconfigs.marketplace.redhat.com
-          specDescriptors:
-          - description: The namespace where the operators will be enabled.
-            displayName: Target Namespace
-            path: targetNamespace
-          - description: List of operator(s) which will be enabled in the target namespace
-            displayName: Packages
-            path: packages
-          statusDescriptors:
-          - description: Current status of the CatalogSourceConfig
-            displayName: Current Phase Name
-            path: currentPhase.phase.name
-          - description: Message associated with the current status
-            displayName: Current Phase Message
-            path: currentPhase.phase.message
-          version: v1alpha1
-      description: Marketplace is a gateway for users to consume off-cluster Operators
-        which will include Red Hat, ISV, optional OpenShift and community content.
-      displayName: marketplace-operator
-      install:
-        spec:
-          clusterPermissions:
-          - rules:
-            - apiGroups:
-              - marketplace.redhat.com
-              resources:
-              - '*'
-              verbs:
-              - '*'
-            - apiGroups:
-              - ''
-              resources:
-              - services
-              - configmaps
-              verbs:
-              - '*'
-            - apiGroups:
-              - operators.coreos.com
-              resources:
-              - catalogsources
-              verbs:
-              - '*'
-            serviceAccountName: marketplace-operator
-          deployments:
-          - name: marketplace-operator
-            spec:
-              replicas: 1
-              selector:
-                matchLabels:
-                  name: marketplace-operator
-              template:
-                metadata:
-                  labels:
+                Please note that this is not a k8s namespace.'
+              displayName: Registry Namespace
+              path: registryNamespace
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+          - description: Represents a CatalogSourceConfig object which is used to configure
+              a CatalogSource.
+            displayName: Catalog Source Config
+            kind: CatalogSourceConfig
+            name: catalogsourceconfigs.marketplace.redhat.com
+            specDescriptors:
+            - description: The namespace where the operators will be enabled.
+              displayName: Target Namespace
+              path: targetNamespace
+            - description: List of operator(s) which will be enabled in the target namespace
+              displayName: Packages
+              path: packages
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+        description: Marketplace is a gateway for users to consume off-cluster Operators
+          which will include Red Hat, ISV, optional OpenShift and community content.
+        displayName: marketplace-operator
+        install:
+          spec:
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - marketplace.redhat.com
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              - apiGroups:
+                - ''
+                resources:
+                - services
+                - configmaps
+                verbs:
+                - '*'
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - catalogsources
+                verbs:
+                - '*'
+              serviceAccountName: marketplace-operator
+            deployments:
+            - name: marketplace-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
                     name: marketplace-operator
-                  name: marketplace-operator
-                spec:
-                  containers:
-                  - command:
-                    - marketplace-operator
-                    env:
-                    - name: WATCH_NAMESPACE
-                      valueFrom:
-                        fieldRef:
-                          fieldPath: metadata.namespace
-                    - name: OPERATOR_NAME
-                      value: marketplace-operator
-                    image: quay.io/openshift/origin-operator-marketplace:latest
-                    imagePullPolicy: Always
-                    livenessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8080
+                template:
+                  metadata:
+                    labels:
+                      name: marketplace-operator
                     name: marketplace-operator
-                    ports:
-                    - containerPort: 60000
-                      name: metrics
-                    - containerPort: 8080
-                      name: healthz
-                    readinessProbe:
-                      httpGet:
-                        path: /healthz
-                        port: 8080
-                  serviceAccountName: marketplace-operator
-        strategy: deployment
-      installModes:
-      - supported: true
-        type: OwnNamespace
-      - supported: true
-        type: SingleNamespace
-      - supported: false
-        type: MultiNamespace
-      - supported: true
-        type: AllNamespaces
-      keywords:
-      - marketplace
-      - catalog
-      - olm
-      - admin
-      labels:
-        name: marketplace-operator
-      links:
-      - name: Markplace Operator Source Code
-        url: https://github.com/operator-framework/operator-marketplace
-      maintainers:
-      - email: aos-marketplace@redhat.com
-        name: AOS Marketplace Team
-      maturity: alpha
-      provider:
-        name: Red Hat
-      selector:
-        matchLabels:
+                  spec:
+                    containers:
+                    - command:
+                      - marketplace-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: marketplace-operator
+                      image: quay.io/openshift/origin-operator-marketplace:latest
+                      imagePullPolicy: Always
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                      name: marketplace-operator
+                      ports:
+                      - containerPort: 60000
+                        name: metrics
+                      - containerPort: 8080
+                        name: healthz
+                      readinessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                    serviceAccountName: marketplace-operator
+          strategy: deployment
+        installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - marketplace
+        - catalog
+        - olm
+        - admin
+        labels:
           name: marketplace-operator
-      version: 0.0.1
-  customResourceDefinitions:
-  - apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        description: Represents a CatalogSourceConfig.
-        displayName: Catalog Source Config
-      name: catalogsourceconfigs.marketplace.redhat.com
-    spec:
-      additionalPrinterColumns:
-      - JSONPath: .spec.targetNamespace
-        description: The namespace where the operators will be enabled
-        name: TargetNamespace
-        type: string
-      - JSONPath: .spec.packages
-        description: List of operator(s) which will be enabled in the target namespace
-        name: Packages
-        type: string
-      - JSONPath: .status.currentPhase.phase.name
-        description: Current status of the CatalogSourceConfig
-        name: Status
-        type: string
-      - JSONPath: .status.currentPhase.phase.message
-        description: Message associated with the current status
-        name: Message
-        type: string
-      - JSONPath: .metadata.creationTimestamp
-        name: Age
-        type: date
-      group: marketplace.redhat.com
-      names:
-        kind: CatalogSourceConfig
-        listKind: CatalogSourceConfigList
-        plural: catalogsourceconfigs
-        shortNames:
-        - csc
-        singular: catalogsourceconfig
-      scope: Namespaced
-      validation:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: Spec for a CatalogSourceConfig
-              properties:
-                packages:
-                  description: Comma separated list of operator(s) without spaces
-                    which will be enabled in the target namespace
-                  type: string
-                targetNamespace:
-                  description: The namespace where the operators will be enabled
-                  type: string
-              required:
-              - targetNamespace
-              - packages
-              type: object
-      version: v1alpha1
-  - apiVersion: apiextensions.k8s.io/v1beta1
-    kind: CustomResourceDefinition
-    metadata:
-      annotations:
-        description: Represents an OperatorSource.
-        displayName: Operator Source
-      name: operatorsources.marketplace.redhat.com
-    spec:
-      additionalPrinterColumns:
-      - JSONPath: .spec.type
-        description: The type of the OperatorSource
-        name: Type
-        type: string
-      - JSONPath: .spec.endpoint
-        description: The endpoint of the OperatorSource
-        name: Endpoint
-        type: string
-      - JSONPath: .spec.registryNamespace
-        description: App registry namespace
-        name: Registry
-        type: string
-      - JSONPath: .spec.displayName
-        description: Display (pretty) name to indicate the OperatorSource's name
-        name: DisplayName
-        type: string
-      - JSONPath: .spec.publisher
-        description: Publisher of the OperatorSource
-        name: Publisher
-        type: string
-      - JSONPath: .status.currentPhase.phase.name
-        description: Current status of the OperatorSource
-        name: Status
-        type: string
-      - JSONPath: .status.currentPhase.phase.message
-        description: Message associated with the current status
-        name: Message
-        type: string
-      - JSONPath: .metadata.creationTimestamp
-        name: Age
-        type: date
-      group: marketplace.redhat.com
-      names:
-        kind: OperatorSource
-        listKind: OperatorSourceList
-        plural: operatorsources
-        shortNames:
-        - opsrc
-        singular: operatorsource
-      scope: Namespaced
-      validation:
-        openAPIV3Schema:
-          properties:
-            spec:
-              description: Spec for an OperatorSource.
-              properties:
-                endpoint:
-                  description: Points to the remote app registry server from where
-                    operator manifests can be fetched.
-                  type: string
-                registryNamespace:
-                  description: 'The namespace in app registry.
+        links:
+        - name: Markplace Operator Source Code
+          url: https://github.com/operator-framework/operator-marketplace
+        maintainers:
+        - email: aos-marketplace@redhat.com
+          name: AOS Marketplace Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        selector:
+          matchLabels:
+            name: marketplace-operator
+        version: 0.0.1
+  customResourceDefinitions: |
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents a CatalogSourceConfig.
+          displayName: Catalog Source Config
+        name: catalogsourceconfigs.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.targetNamespace
+          description: The namespace where the operators will be enabled
+          name: TargetNamespace
+          type: string
+        - JSONPath: .spec.packages
+          description: List of operator(s) which will be enabled in the target namespace
+          name: Packages
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the CatalogSourceConfig
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: CatalogSourceConfig
+          listKind: CatalogSourceConfigList
+          plural: catalogsourceconfigs
+          shortNames:
+          - csc
+          singular: catalogsourceconfig
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for a CatalogSourceConfig
+                properties:
+                  packages:
+                    description: Comma separated list of operator(s) without spaces
+                      which will be enabled in the target namespace
+                    type: string
+                  targetNamespace:
+                    description: The namespace where the operators will be enabled
+                    type: string
+                required:
+                - targetNamespace
+                - packages
+                type: object
+        version: v1alpha1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents an OperatorSource.
+          displayName: Operator Source
+        name: operatorsources.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.type
+          description: The type of the OperatorSource
+          name: Type
+          type: string
+        - JSONPath: .spec.endpoint
+          description: The endpoint of the OperatorSource
+          name: Endpoint
+          type: string
+        - JSONPath: .spec.registryNamespace
+          description: App registry namespace
+          name: Registry
+          type: string
+        - JSONPath: .spec.displayName
+          description: Display (pretty) name to indicate the OperatorSource's name
+          name: DisplayName
+          type: string
+        - JSONPath: .spec.publisher
+          description: Publisher of the OperatorSource
+          name: Publisher
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the OperatorSource
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: OperatorSource
+          listKind: OperatorSourceList
+          plural: operatorsources
+          shortNames:
+          - opsrc
+          singular: operatorsource
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for an OperatorSource.
+                properties:
+                  endpoint:
+                    description: Points to the remote app registry server from where
+                      operator manifests can be fetched.
+                    type: string
+                  registryNamespace:
+                    description: 'The namespace in app registry.
 
-                    Only operator manifests under this namespace will be visible.
+                      Only operator manifests under this namespace will be visible.
 
-                    Please note that this is not a k8s namespace.'
-                  type: string
-                type:
-                  description: The type of the OperatorSource
-                  pattern: appregistry
-                  type: string
-              required:
-              - type
-              - endpoint
-              - registryNamespace
-              type: object
-      version: v1alpha1
-  packages:
-  - channels:
-    - currentCSV: marketplace-operator.v0.0.1
-      name: alpha
-    packageName: marketplace
+                      Please note that this is not a k8s namespace.'
+                    type: string
+                  type:
+                    description: The type of the OperatorSource
+                    pattern: appregistry
+                    type: string
+                required:
+                - type
+                - endpoint
+                - registryNamespace
+                type: object
+        version: v1alpha1
+  packages: |
+    - channels:
+      - currentCSV: marketplace-operator.v0.0.1
+        name: alpha
+      packageName: marketplace

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,6 +1,7 @@
 import pytest
 import yaml
 from operatorcourier.validate import ValidateCmd
+from operatorcourier.format import unformat_bundle
 
 #use same variable name twice!
 
@@ -9,6 +10,7 @@ def test_valid_bundles():
     for bundle in bundles:
         with open(bundle) as f:
             bundle = yaml.safe_load(f)
+            bundle = unformat_bundle(bundle)
             valid = ValidateCmd().validate(bundle)
             assert valid == True
 
@@ -17,5 +19,6 @@ def test_invalid_bundle():
     for bundle in bundles:
         with open(bundle) as f:
             bundle = yaml.safe_load(f)
+            bundle = unformat_bundle(bundle)
             valid = ValidateCmd().validate(bundle)
             assert valid == False


### PR DESCRIPTION
- Set data subfields to strings

This makes the pushed bundle correctly formatted, allowing the backend marketplace operator to properly reconcile the bundle.

/cc @kevinrizza