### PR TITLE
Expect ValueError to be raised

### DIFF
--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -17,8 +17,8 @@ def test_get_operator_artifact_type(fname, expected):
 ("tests/test_files/invalid.yaml"),
 ("tests/test_files/empty.yaml"),
 ])
-@pytest.mark.xfail(raises=ValueError)
 def test_get_operator_artifact_type_assertions(fname):
     with open(fname) as f:
         yaml = f.read()
-        identify.get_operator_artifact_type(yaml)
+        with pytest.raises(ValueError):
+            identify.get_operator_artifact_type(yaml)


### PR DESCRIPTION
According to the pytest docs, `xfail` should be used for tests,
which are expected to fail due to a feature not being implemented,
or a bug not yet fixed.

When the expectation of a test is an error to be raised,
`pytest.raises` should be used to check this expectation.

Signed-off-by: Hunor Csomortáni <csomh@redhat.com>