### PR TITLE
Set up tox

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,5 @@ $ tox
 
 This will run the tests with several versions of Python 3, measure coverage,
 and run flake8 for code linting.
+
+For further details, please see the [contribution guide](docs/contributing.md).

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ $ operator-courier
 ## Testing
 
 ### Running the tests
+
+[Install tox](https://tox.readthedocs.io/en/latest/install.html) and run:
+
 ```bash 
-$ python3 setup.py test
+$ tox
 ```
+
+This will run the tests with several versions of Python 3, measure coverage,
+and run flake8 for code linting.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -1,5 +1,6 @@
 # Contributing to operator-courier
-The following is a set of best practices for contributiong to the operator-courier project. For any questions or concerns please reach out to the AOS-Marketplace team: <aos-marketplace@redhat.com>
+The following is a set of best practices for contributing to the operator-courier project. For any questions or concerns please reach out to the AOS-Marketplace team: <aos-marketplace@redhat.com>
+
 
 ## Development Environment Setup
 This project uses [pipenv](https://github.com/pypa/pipenv) to manage dependencies and create virtual environments for development environment.
@@ -19,6 +20,40 @@ To test the package locally, we need to install dependent pip packages in a way 
 `pipenv shell`
 
 Inside this environment all of the dependent packages are installed without polluting the local environment. For more detailed info, take a look at their (pipenv's) [starter documentation](https://pipenv.readthedocs.io/en/latest/).
+
+
+## Coding style
+
+Changes submitted to this project should follow
+[PEP8](https://www.python.org/dev/peps/pep-0008/) recommendations.
+
+We use [flake8](http://flake8.pycqa.org/en/latest/), a wrapper around
+PyFlakes, PyCodeStyle and McCabe, for checking coding style. You might want to
+read the documentation on the [error
+codes](http://flake8.pycqa.org/en/latest/user/error-codes.html), and check the
+project specific configuration found in the `[flake8]` section of `tox.ini`.
+
+As `flake8` is part of the default tox envlist, code style is checked whenever
+`tox` is run.
+
+
+## Tests and coverage
+
+This project uses [tox](https://tox.readthedocs.io) for running the tests, in
+order to ensure the consistency of the test environments, and make testing
+with multiple Python versions (3.6 and 3.7) easier.
+
+After changes in `tox.ini` or major changes in the working tree (after
+switching branches or pulling from others), it is recommended to use the
+`--recreate` option when running `tox`, to ensure that the test environments
+are up to date.
+
+Coverage is measured using [pytest-cov](https://pypi.org/project/pytest-cov/),
+and it's configured to fail the tests in case the coverage drops bellow a
+certain level. This is intended to ensure that all code changes submitted to
+this project are appropriately unit tested. For the current value, see the
+`[coverage:report]` section in `tox.ini`.
+
 
 ## Release, Deploy, and Clean the Project
 

--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -1,7 +1,8 @@
 """
 operatorcourier.api module
 
-This module implements the api that should be imported when using the operator-courier package
+This module implements the api that should be imported
+when using the operator-courier package
 """
 
 import os
@@ -19,7 +20,9 @@ logger = logging.getLogger(__name__)
 
 
 def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False):
-    """Build and verify constructs an operator bundle from a set of files and then verifies it for usefulness and accuracy.
+    """Build and verify constructs an operator bundle from
+    a set of files and then verifies it for usefulness and accuracy.
+
     It returns the bundle as a string.
 
     :param source_dir: Path to local directory of yaml files to be read.
@@ -28,7 +31,8 @@ def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False):
 
     if source_dir is not None and yamls is not None:
         logger.error("Both source_dir and yamls cannot be defined.")
-        raise TypeError("Both source_dir and yamls cannot be specified on function call.")
+        raise TypeError(
+            "Both source_dir and yamls cannot be specified on function call.")
 
     yaml_files = []
 
@@ -53,11 +57,15 @@ def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False):
     return bundle
 
 
-def build_verify_and_push(namespace, repository, revision, token, source_dir=None, yamls=None):
-    """Build verify and push constructs the operator bundle, verifies it, and pushes it to an external app registry.
-    Currently the only supported app registry is the one located at Quay.io (https://quay.io/cnr/api/v1/packages/)
+def build_verify_and_push(namespace, repository, revision, token,
+                          source_dir=None, yamls=None):
+    """Build verify and push constructs the operator bundle,
+    verifies it, and pushes it to an external app registry.
+    Currently the only supported app registry is the one
+    located at Quay.io (https://quay.io/cnr/api/v1/packages/)
 
-    :param namespace: Quay namespace where the repository we are pushing the bundle is located.
+    :param namespace: Quay namespace where the repository we are
+                      pushing the bundle is located.
     :param repository: Application repository name the application is bundled for.
     :param revision: Release version of the bundle.
     :param source_dir: Path to local directory of yaml files to be read
@@ -75,14 +83,17 @@ def build_verify_and_push(namespace, repository, revision, token, source_dir=Non
             PushCmd().push(temp_dir, namespace, repository, revision, token)
     else:
         logger.error("Bundle is invalid. Will not attempt to push.")
-        raise ValueError("Resulting bundle is invalid, input yaml is improperly defined.")
+        raise ValueError(
+            "Resulting bundle is invalid, input yaml is improperly defined.")
 
 
 def nest(source_dir, registry_dir):
-    """Nest takes a flat bundle directory and version nests it to eventually be consumed as part of an operator-registry image build.
+    """Nest takes a flat bundle directory and version nests it
+    to eventually be consumed as part of an operator-registry image build.
 
     :param source_dir: Path to local directory of yaml files to be read
-    :param output_dir: Path of your directory to be populated. If directory does not exist, it will be created.
+    :param output_dir: Path of your directory to be populated.
+                       If directory does not exist, it will be created.
     """
 
     yaml_files = []

--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -17,6 +17,7 @@ from operatorcourier.nest import nest_bundles
 logging.basicConfig()
 logger = logging.getLogger(__name__)
 
+
 def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False):
     """Build and verify constructs an operator bundle from a set of files and then verifies it for usefulness and accuracy.
     It returns the bundle as a string.
@@ -31,7 +32,7 @@ def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False):
 
     yaml_files = []
 
-    if source_dir is not None: 
+    if source_dir is not None:
         for filename in os.listdir(source_dir):
             if filename.endswith(".yaml") or filename.endswith(".yml"):
                 with open(source_dir + "/" + filename) as f:
@@ -48,8 +49,9 @@ def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False):
         logger.error("Bundle failed validation.")
     else:
         bundle = format_bundle(bundle)
-    
+
     return bundle
+
 
 def build_verify_and_push(namespace, repository, revision, token, source_dir=None, yamls=None):
     """Build verify and push constructs the operator bundle, verifies it, and pushes it to an external app registry.
@@ -61,7 +63,7 @@ def build_verify_and_push(namespace, repository, revision, token, source_dir=Non
     :param source_dir: Path to local directory of yaml files to be read
     :param yamls: List of yaml strings to create bundle with
     """
-    
+
     bundle = build_and_verify(source_dir, yamls)
 
     if bundle is not None:
@@ -75,16 +77,17 @@ def build_verify_and_push(namespace, repository, revision, token, source_dir=Non
         logger.error("Bundle is invalid. Will not attempt to push.")
         raise ValueError("Resulting bundle is invalid, input yaml is improperly defined.")
 
+
 def nest(source_dir, registry_dir):
     """Nest takes a flat bundle directory and version nests it to eventually be consumed as part of an operator-registry image build.
 
     :param source_dir: Path to local directory of yaml files to be read
     :param output_dir: Path of your directory to be populated. If directory does not exist, it will be created.
     """
-    
+
     yaml_files = []
 
-    if source_dir is not None: 
+    if source_dir is not None:
         for filename in os.listdir(source_dir):
             if filename.endswith(".yaml") or filename.endswith(".yml"):
                 with open(source_dir + "/" + filename) as f:

--- a/operatorcourier/build.py
+++ b/operatorcourier/build.py
@@ -4,7 +4,7 @@ import operatorcourier.identify as identify
 
 class BuildCmd():
     def _get_empty_bundle(self):
-         return dict(
+        return dict(
             data=dict(
                 customResourceDefinitions=[],
                 clusterServiceVersions=[],

--- a/operatorcourier/build.py
+++ b/operatorcourier/build.py
@@ -1,16 +1,17 @@
 import yaml
 import operatorcourier.identify as identify
 
+
 class BuildCmd():
     def _get_empty_bundle(self):
          return dict(
-            data = dict(
-                customResourceDefinitions = [],
-                clusterServiceVersions = [],
-                packages = [],
+            data=dict(
+                customResourceDefinitions=[],
+                clusterServiceVersions=[],
+                packages=[],
             )
         )
-    
+
     def _get_field_entry(self, yamlContent):
         yaml_type = identify.get_operator_artifact_type(yamlContent)
         return yaml_type[0:1].lower() + yaml_type[1:] + 's'
@@ -25,7 +26,7 @@ class BuildCmd():
 
         :param strings: Array of yaml strings to bundle
         """
-        bundle =  self._get_empty_bundle()
+        bundle = self._get_empty_bundle()
         for item in strings:
             bundle = self._updateBundle(bundle, item)
 

--- a/operatorcourier/build.py
+++ b/operatorcourier/build.py
@@ -17,12 +17,13 @@ class BuildCmd():
         return yaml_type[0:1].lower() + yaml_type[1:] + 's'
 
     def _updateBundle(self, operatorBundle, yamlContent):
-        operatorBundle["data"][self._get_field_entry(yamlContent)].append(yaml.safe_load(yamlContent))
+        field_entry = operatorBundle["data"][self._get_field_entry(yamlContent)]
+        field_entry.append(yaml.safe_load(yamlContent))
         return operatorBundle
 
     def build_bundle(self, strings):
-        """build_bundle takes an array of yaml files and generates a 'bundle' with those yaml files
-        generated in the bundle format.
+        """build_bundle takes an array of yaml files and generates a 'bundle'
+        with those yaml files generated in the bundle format.
 
         :param strings: Array of yaml strings to bundle
         """

--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -24,7 +24,8 @@ class _CliParser():
         """Parse generates and evaluates the command level parser
         """
         parser = argparse.ArgumentParser(
-            description='Build, verify and push operator bundles into external app registry',
+            description='Build, verify and push operator bundles into '
+                        'external app registry',
             usage='''operator-courier <command> [<args>]
 
 These are the commands you can use:
@@ -42,30 +43,51 @@ These are the commands you can use:
 
     # Parse the verify command
     def verify(self):
-        parser = argparse.ArgumentParser(description='Build and verify an operator bundle to test')
-        parser.add_argument('source_dir', help='Path of your directory of yaml files to bundle. Either set this or use the files argument for bundle data.')
-        parser.add_argument('--ui_validate_io', help='Validate bundle for operatorhub.io UI', action='store_true')
+        parser = argparse.ArgumentParser(
+            description='Build and verify an operator bundle to test')
+        parser.add_argument('source_dir', help='Path of your directory of yaml '
+                            'files to bundle. Either set this or '
+                            'use the files argument for bundle data.')
+        parser.add_argument('--ui_validate_io',
+                            help='Validate bundle for operatorhub.io UI',
+                            action='store_true')
 
         args, leftovers = parser.parse_known_args(sys.argv[2:])
         api.build_and_verify(source_dir=args.source_dir, ui_validate_io=args.ui_validate_io)
 
     # Parse the push command
     def push(self):
-        parser = argparse.ArgumentParser(description='Build, verify and push an operator bundle into external app registry.')
-        parser.add_argument('source_dir', help='Path of your directory of yaml files to bundle.')
-        parser.add_argument('namespace', help='Name of the Quay namespace to push operator to.')
-        parser.add_argument('repository', help='Application repository name the application is bundled for.')
-        parser.add_argument('release', help='The release version of the bundle.')
+        parser = argparse.ArgumentParser(
+            description='Build, verify and push an operator bundle '
+                        'into external app registry.')
+        parser.add_argument('source_dir',
+                            help='Path of your directory of yaml files to bundle.')
+        parser.add_argument('namespace',
+                            help='Name of the Quay namespace to push operator to.')
+        parser.add_argument('repository',
+                            help='Application repository name '
+                                 'the application is bundled for.')
+        parser.add_argument('release',
+                            help='The release version of the bundle.')
         parser.add_argument('token', help='Authorization token for Quay api.')
 
         args, leftovers = parser.parse_known_args(sys.argv[2:])
-        api.build_verify_and_push(args.namespace, args.repository, args.release, args.token, source_dir=args.source_dir)
+        api.build_verify_and_push(args.namespace,
+                                  args.repository,
+                                  args.release,
+                                  args.token,
+                                  source_dir=args.source_dir)
 
     # Parse the nest command
     def nest(self):
-        parser = argparse.ArgumentParser(description='Take a flat bundle directory and version nest it to eventually create an operator-registry image.')
-        parser.add_argument('source_dir', help='Path of your directory of yaml files to bundle.')
-        parser.add_argument('registry_dir', help='Path of your directory to be populated. If directory does not exist, it will be created.')
+        parser = argparse.ArgumentParser(
+            description='Take a flat bundle directory and version nest it '
+                        'to eventually create an operator-registry image.')
+        parser.add_argument('source_dir',
+                            help='Path of your directory of yaml files to bundle.')
+        parser.add_argument('registry_dir',
+                            help='Path of your directory to be populated. '
+                                 'If directory does not exist, it will be created.')
 
         args, leftovers = parser.parse_known_args(sys.argv[2:])
         api.nest(args.source_dir, args.registry_dir)

--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -2,6 +2,7 @@ import argparse
 import sys
 from operatorcourier import api
 
+
 def main():
     """Generate the CLI bits
     """
@@ -10,6 +11,7 @@ def main():
         parser.parse()
     except Exception as e:  # Exception raised to CLI should not be thrown to users,
         sys.exit(str(e))    # it should just be captured by logs
+
 
 class _CliParser():
     """Class that generates the command line bits for the operator-courier cli tool
@@ -35,7 +37,7 @@ These are the commands you can use:
         args = parser.parse_args(sys.argv[1:2])
         if not hasattr(self, args.command):
             parser.error('Unrecognized command')
-        
+
         getattr(self, args.command)()
 
     # Parse the verify command
@@ -44,9 +46,9 @@ These are the commands you can use:
         parser.add_argument('source_dir', help='Path of your directory of yaml files to bundle. Either set this or use the files argument for bundle data.')
         parser.add_argument('--ui_validate_io', help='Validate bundle for operatorhub.io UI', action='store_true')
 
-        args, leftovers = parser.parse_known_args(sys.argv[2:])       
+        args, leftovers = parser.parse_known_args(sys.argv[2:])
         api.build_and_verify(source_dir=args.source_dir, ui_validate_io=args.ui_validate_io)
-    
+
     # Parse the push command
     def push(self):
         parser = argparse.ArgumentParser(description='Build, verify and push an operator bundle into external app registry.')

--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -53,7 +53,8 @@ These are the commands you can use:
                             action='store_true')
 
         args, leftovers = parser.parse_known_args(sys.argv[2:])
-        api.build_and_verify(source_dir=args.source_dir, ui_validate_io=args.ui_validate_io)
+        api.build_and_verify(source_dir=args.source_dir,
+                             ui_validate_io=args.ui_validate_io)
 
     # Parse the push command
     def push(self):

--- a/operatorcourier/const_io.py
+++ b/operatorcourier/const_io.py
@@ -4,94 +4,123 @@ general_required_fields = [
 
 metadata_required_fields = [
     {
-        "field" : "annotations",
-        "description" : "Without this field, your operator will be missing essential data for the UI. Please add this field to the CSV and run validation again to see what subfields are required.",
-        "required" : True
+        "field": "annotations",
+        "description": "Without this field, your operator will be missing "
+                       "essential data for the UI. Please add this field to the "
+                       "CSV and run validation again to see what subfields "
+                       "are required.",
+        "required": True
     }
 ]
 
 metadata_annotations_required_fields = [
     {
-        "field" : "description",
-        "description" : "Without this field, the description displayed in the tiles of the UI will be a truncated version of spec.description.",
-        "required" : True
+        "field": "description",
+        "description": "Without this field, the description displayed in "
+                       "the tiles of the UI will be a truncated "
+                       "version of spec.description.",
+        "required": True
     },
     {
-        "field" : "categories",
-        "description" : "Without this field, the operator will be categorized as Other.",
-        "required" : False
+        "field": "categories",
+        "description": "Without this field, the operator will be "
+                       "categorized as Other.",
+        "required": False
     },
     {
-        "field" : "capabilities",
-        "description" : "Without this field, the operator will be assigned the basic install capability - you can read more about operator maturity models here https://www.operatorhub.io/getting-started#How-do-I-start-writing-an-Operator?.",
-        "required" : True
+        "field": "capabilities",
+        "description": "Without this field, the operator will be assigned "
+                       "the basic install capability - you can read more "
+                       "about operator maturity models here "
+                       "https://www.operatorhub.io/getting-started#How-do-I-start-writing-an-Operator?.",  # noqa
+        "required": True
     },
     {
-        "field" : "repository",
-        "description" : "Without this field, the link to the operator source code will not be displayed in the UI.",
-        "required" : False
+        "field": "repository",
+        "description": "Without this field, the link to the operator source "
+                       "code will not be displayed in the UI.",
+        "required": False
     },
     {
-        "field" : "createdAt",
-        "description" : "Without this field, the time stamp at which the operator was created will not be displayed in the UI.",
-        "required" : False
+        "field": "createdAt",
+        "description": "Without this field, the time stamp at which the "
+                       "operator was created will not be displayed in the UI.",
+        "required": False
     },
     {
-        "field" : "containerImage",
-        "description" : "Without this field, the link to the operator image will not be displayed in the UI.",
-        "required" : True
+        "field": "containerImage",
+        "description": "Without this field, the link to the operator "
+                       "image will not be displayed in the UI.",
+        "required": True
     },
     {
-        "field" : "alm-examples",
-        "description" : "Without this field, users will not have examples of how to write Custom Resources for the operator.",
-        "required" : False
+        "field": "alm-examples",
+        "description": "Without this field, users will not have examples "
+                       "of how to write Custom Resources for the operator.",
+        "required": False
     }
 ]
 
 spec_required_fields = [
     {
-        "field" : "displayName",
-        "description" : "Without this field, the name of the operator for both the tile and the details view will default to metadata.name.",
-        "required" : True
+        "field": "displayName",
+        "description": "Without this field, the name of the operator for "
+                       "both the tile and the details view will default "
+                       "to metadata.name.",
+        "required": True
     },
     {
-        "field" : "description",
-        "description" : "Without this field, the description in the details view of the operator will default to metadata.annotations.description.",
-        "required" : True
+        "field": "description",
+        "description": "Without this field, the description in the details "
+                       "view of the operator will default to "
+                       "metadata.annotations.description.",
+        "required": True
     },
     {
-        "field" : "version",
-        "description" : "Without this field, the version in the details view of the operator will be empty.",
-        "required" : True
+        "field": "version",
+        "description": "Without this field, the version in the details "
+                       "view of the operator will be empty.",
+        "required": True
     },
     {
-        "field" : "links",
-        "description" : "Without this field, no links will be displayed in the details page side panel. You can for example link to some additional Documentation, related Blogs or Repositories.",
-        "required" : True
+        "field": "links",
+        "description": "Without this field, no links will be displayed "
+                       "in the details page side panel. You can for "
+                       "example link to some additional Documentation, "
+                       "related Blogs or Repositories.",
+        "required": True
     },
     {
-        "field" : "icon",
-        "description" : "Without this field, the operator will display a default operator framework icon.",
-        "required" : False
+        "field": "icon",
+        "description": "Without this field, the operator will display "
+                       "a default operator framework icon.",
+        "required": False
     },
     {
-        "field" : "provider",
-        "description" : "Without this field, users will not be able to filter for provider.",
-        "required" : True
+        "field": "provider",
+        "description": "Without this field, users will not be able "
+                       "to filter for provider.",
+        "required": True
     },
     {
-        "field" : "maintainers",
-        "description" : "Without this field, the operator details page will not display the name and contact for users to get support in using the operator. The field should be a yaml list of name & email pairs.",
-        "required" : True
+        "field": "maintainers",
+        "description": "Without this field, the operator details page "
+                       "will not display the name and contact for users "
+                       "to get support in using the operator. "
+                       "The field should be a yaml list of name & email pairs.",
+        "required": True
     },
     {
-        "field" : "customresourcedefinitions",
-        "description" : "Without this field, the operator details page will not display any CRDs the operator needs in order to function.",
-        "required" : False
+        "field": "customresourcedefinitions",
+        "description": "Without this field, the operator details page will "
+                       "not display any CRDs the operator needs "
+                       "in order to function.",
+        "required": False
     },
     {
-        "field" : "installModes",
-        "description" : "Without this field, OLM will not be able to deploy your operator.",
-        "required" : True
+        "field": "installModes",
+        "description": "Without this field, OLM will not be able "
+                       "to deploy your operator.",
+        "required": True
     }
 ]

--- a/operatorcourier/format.py
+++ b/operatorcourier/format.py
@@ -2,7 +2,8 @@ import yaml
 from operatorcourier.build import BuildCmd
 
 
-class _literal(str): pass
+class _literal(str):
+    pass
 
 
 def _literal_presenter(dumper, data):

--- a/operatorcourier/format.py
+++ b/operatorcourier/format.py
@@ -1,25 +1,29 @@
 import yaml
 from operatorcourier.build import BuildCmd
 
+
 class _literal(str): pass
+
 
 def _literal_presenter(dumper, data):
     return dumper.represent_scalar('tag:yaml.org,2002:str', data, style='|')
 
+
 def _get_empty_formatted_bundle():
     return dict(
-        data = dict(
-            customResourceDefinitions = '',
-            clusterServiceVersions = '',
-            packages = '',
+        data=dict(
+            customResourceDefinitions='',
+            clusterServiceVersions='',
+            packages='',
         )
     )
+
 
 def format_bundle(bundle):
     """
     Converts a bundle object into a push-ready bundle by changing list values of 'customResourceDefinitions', 'clusterServiceVersions', and 'packages' into stringified yaml literals.
     This format is required by the Marketplace backend.
-    
+
     :param bundle: A bundle object
     """
 
@@ -41,13 +45,13 @@ def format_bundle(bundle):
                     if 'annotations' in csv['metadata']:
                         if 'alm-examples' in csv['metadata']['annotations']:
                             csv['metadata']['annotations']['alm-examples'] = _literal(csv['metadata']['annotations']['alm-examples'])
-                
+
                 if 'spec' in csv:
                     if 'description' in csv['spec']:
                         csv['spec']['description'] = _literal(csv['spec']['description'])
-                
+
                 clusterServiceVersions.append(csv)
-            
+
             if len(clusterServiceVersions) > 0:
                 formattedBundle['data']['clusterServiceVersions'] = _literal(yaml.dump(clusterServiceVersions, default_flow_style=False))
 
@@ -56,6 +60,7 @@ def format_bundle(bundle):
                 formattedBundle['data']['packages'] = _literal(yaml.dump(bundle['data']['packages'], default_flow_style=False))
 
     return formattedBundle
+
 
 def unformat_bundle(formattedBundle):
     """
@@ -66,13 +71,13 @@ def unformat_bundle(formattedBundle):
     """
 
     bundle = BuildCmd()._get_empty_bundle()
- 
+
     if 'data' in formattedBundle:
         if 'customResourceDefinitions' in formattedBundle['data']:
             customResourceDefinitions = yaml.safe_load(formattedBundle['data']['customResourceDefinitions'])
             if customResourceDefinitions and len(customResourceDefinitions) > 0:
                 bundle['data']['customResourceDefinitions'] = customResourceDefinitions
-        
+
         if 'clusterServiceVersions' in formattedBundle['data']:
             clusterServiceVersions = yaml.safe_load(formattedBundle['data']['clusterServiceVersions'])
             if clusterServiceVersions and len(clusterServiceVersions) > 0:

--- a/operatorcourier/format.py
+++ b/operatorcourier/format.py
@@ -22,7 +22,10 @@ def _get_empty_formatted_bundle():
 
 def format_bundle(bundle):
     """
-    Converts a bundle object into a push-ready bundle by changing list values of 'customResourceDefinitions', 'clusterServiceVersions', and 'packages' into stringified yaml literals.
+    Converts a bundle object into a push-ready bundle by
+    changing list values of 'customResourceDefinitions',
+    'clusterServiceVersions', and 'packages' into stringified yaml literals.
+
     This format is required by the Marketplace backend.
 
     :param bundle: A bundle object
@@ -32,40 +35,44 @@ def format_bundle(bundle):
 
     yaml.add_representer(_literal, _literal_presenter)
 
-    if 'data' in bundle:
-        # Format data fields as string literals to match backend expected format
-        if 'customResourceDefinitions' in bundle['data']:
-            if len(bundle['data']['customResourceDefinitions']) > 0:
-                formattedBundle['data']['customResourceDefinitions'] = _literal(yaml.dump(bundle['data']['customResourceDefinitions'], default_flow_style=False))
+    if 'data' not in bundle:
+        return formattedBundle
 
-        if 'clusterServiceVersions' in bundle['data']:
-            # Format description and alm-examples
-            clusterServiceVersions = []
-            for csv in bundle['data']['clusterServiceVersions']:
-                if 'metadata' in csv:
-                    if 'annotations' in csv['metadata']:
-                        if 'alm-examples' in csv['metadata']['annotations']:
-                            csv['metadata']['annotations']['alm-examples'] = _literal(csv['metadata']['annotations']['alm-examples'])
+    # Format data fields as string literals to match backend expected format
+    if bundle['data'].get('customResourceDefinitions'):
+        formattedBundle['data']['customResourceDefinitions'] = _literal(
+            yaml.dump(bundle['data']['customResourceDefinitions'],
+                      default_flow_style=False))
 
-                if 'spec' in csv:
-                    if 'description' in csv['spec']:
-                        csv['spec']['description'] = _literal(csv['spec']['description'])
+    if 'clusterServiceVersions' in bundle['data']:
+        # Format description and alm-examples
+        clusterServiceVersions = []
+        for csv in bundle['data']['clusterServiceVersions']:
+            if csv.get('metadata', {}).get('annotations', {}).get('alm-examples'):
+                csv['metadata']['annotations']['alm-examples'] = _literal(
+                    csv['metadata']['annotations']['alm-examples'])
 
-                clusterServiceVersions.append(csv)
+            if csv.get('spec', {}).get('description'):
+                csv['spec']['description'] = _literal(csv['spec']['description'])
 
-            if len(clusterServiceVersions) > 0:
-                formattedBundle['data']['clusterServiceVersions'] = _literal(yaml.dump(clusterServiceVersions, default_flow_style=False))
+            clusterServiceVersions.append(csv)
 
-        if 'packages' in bundle['data']:
-            if len(bundle['data']['packages']) > 0:
-                formattedBundle['data']['packages'] = _literal(yaml.dump(bundle['data']['packages'], default_flow_style=False))
+        if clusterServiceVersions:
+            formattedBundle['data']['clusterServiceVersions'] = _literal(
+                yaml.dump(clusterServiceVersions, default_flow_style=False))
+
+    if bundle['data'].get('packages'):
+        formattedBundle['data']['packages'] = _literal(
+            yaml.dump(bundle['data']['packages'], default_flow_style=False))
 
     return formattedBundle
 
 
 def unformat_bundle(formattedBundle):
     """
-    Converts a push-ready bundle into a structured object by changing stringified yaml of 'customResourceDefinitions', 'clusterServiceVersions', and 'packages' into lists of objects.
+    Converts a push-ready bundle into a structured object by changing
+    stringified yaml of 'customResourceDefinitions', 'clusterServiceVersions',
+    and 'packages' into lists of objects.
     Undoing the format helps simplify bundle validation.
 
     :param formattedBundle: A push-ready bundle
@@ -73,20 +80,24 @@ def unformat_bundle(formattedBundle):
 
     bundle = BuildCmd()._get_empty_bundle()
 
-    if 'data' in formattedBundle:
-        if 'customResourceDefinitions' in formattedBundle['data']:
-            customResourceDefinitions = yaml.safe_load(formattedBundle['data']['customResourceDefinitions'])
-            if customResourceDefinitions and len(customResourceDefinitions) > 0:
-                bundle['data']['customResourceDefinitions'] = customResourceDefinitions
+    if 'data' not in formattedBundle:
+        return bundle
 
-        if 'clusterServiceVersions' in formattedBundle['data']:
-            clusterServiceVersions = yaml.safe_load(formattedBundle['data']['clusterServiceVersions'])
-            if clusterServiceVersions and len(clusterServiceVersions) > 0:
-                bundle['data']['clusterServiceVersions'] = clusterServiceVersions
+    if 'customResourceDefinitions' in formattedBundle['data']:
+        customResourceDefinitions = yaml.safe_load(
+            formattedBundle['data']['customResourceDefinitions'])
+        if customResourceDefinitions:
+            bundle['data']['customResourceDefinitions'] = customResourceDefinitions
 
-        if 'packages' in formattedBundle['data']:
-            packages = yaml.safe_load(formattedBundle['data']['packages'])
-            if packages and len(packages) > 0:
-                bundle['data']['packages'] = packages
+    if 'clusterServiceVersions' in formattedBundle['data']:
+        clusterServiceVersions = yaml.safe_load(
+            formattedBundle['data']['clusterServiceVersions'])
+        if clusterServiceVersions:
+            bundle['data']['clusterServiceVersions'] = clusterServiceVersions
+
+    if 'packages' in formattedBundle['data']:
+        packages = yaml.safe_load(formattedBundle['data']['packages'])
+        if packages:
+            bundle['data']['packages'] = packages
 
     return bundle

--- a/operatorcourier/identify.py
+++ b/operatorcourier/identify.py
@@ -5,6 +5,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+
 def get_operator_artifact_type(operatorArtifactString):
     """get_operator_artifact_type takes a yaml string and determines if it is one of the
     expected bundle types: ClusterServiceVersion, CustomResourceDefinition, or Package.

--- a/operatorcourier/identify.py
+++ b/operatorcourier/identify.py
@@ -5,7 +5,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-
 def get_operator_artifact_type(operatorArtifactString):
     """get_operator_artifact_type takes a yaml string and determines if it is
     one of the expected bundle types: ClusterServiceVersion,

--- a/operatorcourier/identify.py
+++ b/operatorcourier/identify.py
@@ -7,8 +7,9 @@ logger = logging.getLogger(__name__)
 
 
 def get_operator_artifact_type(operatorArtifactString):
-    """get_operator_artifact_type takes a yaml string and determines if it is one of the
-    expected bundle types: ClusterServiceVersion, CustomResourceDefinition, or Package.
+    """get_operator_artifact_type takes a yaml string and determines if it is
+    one of the expected bundle types: ClusterServiceVersion,
+    CustomResourceDefinition, or Package.
 
     :param operatorArtifactString: Yaml string to type check
     """
@@ -24,10 +25,10 @@ def get_operator_artifact_type(operatorArtifactString):
             if "packageName" in operatorArtifact:
                 artifact_type = "Package"
                 artifact_name = operatorArtifact['packageName']
-            elif "kind" in operatorArtifact:
-                if operatorArtifact["kind"] in ("ClusterServiceVersion", "CustomResourceDefinition"):
-                    artifact_type = operatorArtifact["kind"]
-                    artifact_name = operatorArtifact['metadata']['name']
+            elif operatorArtifact.get("kind") in ("ClusterServiceVersion",
+                                                  "CustomResourceDefinition"):
+                artifact_type = operatorArtifact["kind"]
+                artifact_name = operatorArtifact['metadata']['name']
             if artifact_type is not None:
                 logger.info('Parsed %s: %s', artifact_type, artifact_name)
                 return artifact_type

--- a/operatorcourier/nest.py
+++ b/operatorcourier/nest.py
@@ -42,7 +42,8 @@ def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
         yaml.dump(package, outfile, default_flow_style=False)
         outfile.flush()
 
-    # now lets create a subdirectory for each version of the csv, and add all the relevant crds to it
+    # now lets create a subdirectory for each version of the csv,
+    # and add all the relevant crds to it
     for csv in csvs:
         csv_name = csv["metadata"]["name"]
         version = csv["spec"]["version"]
@@ -51,7 +52,8 @@ def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
         if not os.path.exists(csv_folder):
             os.makedirs(csv_folder)
 
-        with open('%s/%s.clusterserviceversion.yaml' % (csv_folder, csv_name), 'w') as outfile:
+        csv_path = '%s/%s.clusterserviceversion.yaml' % (csv_folder, csv_name)
+        with open(csv_path, 'w') as outfile:
             yaml.dump(csv, outfile, default_flow_style=False)
             outfile.flush()
 
@@ -64,7 +66,8 @@ def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
                     yaml.dump(crd, outfile, default_flow_style=False)
                     outfile.flush()
             else:
-                errors.append("CRD %s mentioned in CSV %s was not found in directory." % (crd_name, csv_name))
+                errors.append("CRD %s mentioned in CSV %s was not found in directory."
+                              % (crd_name, csv_name))
 
     # if no errors were encountered, lets create the real directory and populate it.
     if len(errors) == 0:

--- a/operatorcourier/nest.py
+++ b/operatorcourier/nest.py
@@ -6,6 +6,7 @@ import operatorcourier.identify as identify
 
 logger = logging.getLogger(__name__)
 
+
 def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
     package = {}
     crds = {}

--- a/operatorcourier/push.py
+++ b/operatorcourier/push.py
@@ -1,5 +1,4 @@
 import base64
-import os
 import requests
 import tarfile
 import logging

--- a/operatorcourier/push.py
+++ b/operatorcourier/push.py
@@ -6,12 +6,13 @@ from tempfile import TemporaryDirectory
 
 logger = logging.getLogger(__name__)
 
+
 class PushCmd():
     name = 'push'
 
     def __init__(self):
         pass
-        
+
     def push(self, bundle_dir, namespace, repository, release, auth_token):
         """Push takes a bundle and pushes it to the specified app registry repository.
 
@@ -27,7 +28,7 @@ class PushCmd():
 
     def _create_base64_bundle(self, bundle_dir, repository):
         with TemporaryDirectory() as temp_dir:
-            tarfile_name = "%s/%s.tar.gz" % (temp_dir,repository)
+            tarfile_name = "%s/%s.tar.gz" % (temp_dir, repository)
             with tarfile.open(tarfile_name, "w:gz") as tar:
                 tar.add(bundle_dir, "")
             with open(tarfile_name, "rb") as tarball:

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -40,11 +40,15 @@ class ValidateCmd():
 
         bundleData = bundle[self.dataKey]
 
-        validationDict[self.crdKey] = self._type_validation(bundleData, self.crdKey, self._crd_validation, False)
-        validationDict[self.csvKey] = self._type_validation(bundleData, self.csvKey, self._csv_validation, True)
-        validationDict[self.pkgsKey] = self._type_validation(bundleData, self.pkgsKey, self._pkgs_validation, True)
+        validationDict[self.crdKey] = self._type_validation(bundleData, self.crdKey,
+                                                            self._crd_validation, False)
+        validationDict[self.csvKey] = self._type_validation(bundleData, self.csvKey,
+                                                            self._csv_validation, True)
+        validationDict[self.pkgsKey] = self._type_validation(bundleData, self.pkgsKey,
+                                                             self._pkgs_validation, True)
         if self.ui_validate_io:
-            validationDict[self.csvKey] &= self._type_validation(bundleData, self.csvKey, self._ui_validation_io, True)
+            validationDict[self.csvKey] &= self._type_validation(
+                bundleData, self.csvKey, self._ui_validation_io, True)
 
         valid = True
         for key, value in validationDict.items():
@@ -110,7 +114,8 @@ class ValidateCmd():
     def _csv_spec_validation(self, spec, bundleData):
         valid = True
 
-        warnSpecList = ["displayName", "description", "icon", "version", "provider", "maturity"]
+        warnSpecList = ["displayName", "description", "icon",
+                        "version", "provider", "maturity"]
 
         for item in warnSpecList:
             if item not in spec:
@@ -141,11 +146,13 @@ class ValidateCmd():
             else:
                 for crd in customresourcedefinitions["owned"]:
                     if "name" not in crd:
-                        logger.error("name not defined for item in spec.customresourcedefinitions.")
+                        logger.error("name not defined for item in "
+                                     "spec.customresourcedefinitions.")
                         valid = False
                     else:
                         if crd["name"] not in crdList:
-                            logger.error("custom resource definition referenced in csv not defined in root list of crds")
+                            logger.error("custom resource definition referenced "
+                                         "in csv not defined in root list of crds")
 
         return valid
 
@@ -161,7 +168,8 @@ class ValidateCmd():
         if "annotations" in metadata:
             annotations = metadata["annotations"]
 
-            annotationList = ["categories", "description", "containerImage", "createdAt", "support"]
+            annotationList = ["categories", "description",
+                              "containerImage", "createdAt", "support"]
 
             for item in annotationList:
                 if item not in annotations:
@@ -181,7 +189,8 @@ class ValidateCmd():
                 try:
                     json.loads(annotations["alm-examples"])
                 except KeyError:
-                    logger.error("metadata.annotations.alm-examples contains invalid json string")
+                    logger.error("metadata.annotations.alm-examples contains "
+                                 "invalid json string")
                     valid = False
 
         else:
@@ -224,7 +233,9 @@ class ValidateCmd():
                             logger.error("package channel.currentCSV not defined.")
                         else:
                             if channel["currentCSV"] not in csvNames:
-                                logger.error("channel.currentCSV %s is not included in list of csvs", channel["currentCSV"])
+                                logger.error("channel.currentCSV %s is not "
+                                             "included in list of csvs",
+                                             channel["currentCSV"])
                                 valid = False
 
             else:
@@ -257,7 +268,7 @@ class ValidateCmd():
             if self._ui_csv_fields_exist_validation_io(csv) is False:
                 logger.error("UI validation failed to verify required fields for operatorhub.io exist.")
                 valid = False
-            
+
             if valid:
                 if self._ui_csv_fields_format_validation_io(csv) is False:
                     logger.error("UI validation failed to verify that required fields for operatorhub.io are properly formatted.")
@@ -283,7 +294,7 @@ class ValidateCmd():
                         logger.error("csv %s not defined.", field)
                         valid = False
                         return valid
-                
+
                 for field in metadata_required_fields:
                     if field["field"] not in csv["metadata"]:
                         if field["required"]:
@@ -292,7 +303,7 @@ class ValidateCmd():
                             return valid
                         else:
                             logger.warning("csv metadata.%s not defined. %s", field["field"], field["description"])
-                
+
                 for field in metadata_annotations_required_fields:
                     if field["field"] not in csv["metadata"]["annotations"]:
                         if field["required"]:
@@ -310,7 +321,7 @@ class ValidateCmd():
                             logger.warning("csv spec.%s not defined. %s", field["field"], field["description"])
 
         return valid
-    
+
     def _ui_csv_fields_format_validation_io(self, csv):
 
         def is_url(field):
@@ -349,7 +360,7 @@ class ValidateCmd():
         spec = csv["spec"]
         provider = spec["provider"]
         annotations = csv["metadata"]["annotations"]
-        
+
         # alm-examples check based on crd field
         if "customresourcedefinitions" in spec:
             if "owned" in spec["customresourcedefinitions"]:
@@ -363,7 +374,7 @@ class ValidateCmd():
                 else:
                     logger.error("You should have alm-examples for every owned CRD")
                     valid = False
-        
+
         # provider check
         if isinstance(provider, (dict,)):
             if len(provider) != 1:
@@ -376,7 +387,7 @@ class ValidateCmd():
         else:
             logger.error("csv.spec.provider should contain a \"name\" field.")
             valid = False
-        
+
         # maintainers check
         if isinstance(spec["maintainers"], (list,)):
             for maintainer in spec["maintainers"]:

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -35,7 +35,7 @@ class ValidateCmd():
 
         if self.dataKey not in bundle:
             logger.error("Bundle does not contain base data field.")
-            #break here because there's nothing else to learn
+            # break here because there's nothing else to learn
             return False
 
         bundleData = bundle[self.dataKey]
@@ -179,7 +179,7 @@ class ValidateCmd():
             # if alm-examples is defined, check that its value is valid json
             if "alm-examples" in annotations:
                 try:
-                    valid_json = json.loads(annotations["alm-examples"])
+                    json.loads(annotations["alm-examples"])
                 except KeyError:
                     logger.error("metadata.annotations.alm-examples contains invalid json string")
                     valid = False

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -8,6 +8,7 @@ from .const_io import general_required_fields, metadata_required_fields, metadat
 
 logger = logging.getLogger(__name__)
 
+
 class ValidateCmd():
     dataKey = "data"
     crdKey = "customResourceDefinitions"
@@ -17,7 +18,7 @@ class ValidateCmd():
     def __init__(self, ui_validate_io=False):
         self.ui_validate_io = ui_validate_io
         pass
-        
+
     def validate(self, bundle):
         """validate takes a bundle as a dictionary and returns a boolean value that
         describes if the bundle is valid. It also logs verification information when
@@ -39,7 +40,7 @@ class ValidateCmd():
 
         bundleData = bundle[self.dataKey]
 
-        validationDict[self.crdKey] = self._type_validation(bundleData, self.crdKey, self._crd_validation, False)  
+        validationDict[self.crdKey] = self._type_validation(bundleData, self.crdKey, self._crd_validation, False)
         validationDict[self.csvKey] = self._type_validation(bundleData, self.csvKey, self._csv_validation, True)
         validationDict[self.pkgsKey] = self._type_validation(bundleData, self.pkgsKey, self._pkgs_validation, True)
         if self.ui_validate_io:
@@ -49,7 +50,7 @@ class ValidateCmd():
         for key, value in validationDict.items():
             if value is False:
                 valid = False
-        
+
         return valid
 
     def _crd_validation(self, bundleData):
@@ -110,7 +111,7 @@ class ValidateCmd():
         valid = True
 
         warnSpecList = ["displayName", "description", "icon", "version", "provider", "maturity"]
-        
+
         for item in warnSpecList:
             if item not in spec:
                 logger.warning("csv spec.%s not defined" % item)

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -4,7 +4,11 @@ import re
 
 import validators as v
 
-from .const_io import general_required_fields, metadata_required_fields, metadata_annotations_required_fields, spec_required_fields
+from .const_io import (
+    general_required_fields,
+    metadata_required_fields,
+    metadata_annotations_required_fields,
+    spec_required_fields)
 
 logger = logging.getLogger(__name__)
 
@@ -266,12 +270,14 @@ class ValidateCmd():
 
         for csv in csvs:
             if self._ui_csv_fields_exist_validation_io(csv) is False:
-                logger.error("UI validation failed to verify required fields for operatorhub.io exist.")
+                logger.error("UI validation failed to verify required "
+                             "fields for operatorhub.io exist.")
                 valid = False
 
             if valid:
                 if self._ui_csv_fields_format_validation_io(csv) is False:
-                    logger.error("UI validation failed to verify that required fields for operatorhub.io are properly formatted.")
+                    logger.error("UI validation failed to verify that required "
+                                 "fields for operatorhub.io are properly formatted.")
                     valid = False
 
         return valid
@@ -298,27 +304,33 @@ class ValidateCmd():
                 for field in metadata_required_fields:
                     if field["field"] not in csv["metadata"]:
                         if field["required"]:
-                            logger.error("csv metadata.%s not defined. %s", field["field"], field["description"])
+                            logger.error("csv metadata.%s not defined. %s",
+                                         field["field"], field["description"])
                             valid = False
                             return valid
                         else:
-                            logger.warning("csv metadata.%s not defined. %s", field["field"], field["description"])
+                            logger.warning("csv metadata.%s not defined. %s",
+                                           field["field"], field["description"])
 
                 for field in metadata_annotations_required_fields:
                     if field["field"] not in csv["metadata"]["annotations"]:
                         if field["required"]:
-                            logger.error("csv metadata.annotations.%s not defined. %s", field["field"], field["description"])
+                            logger.error("csv metadata.annotations.%s not defined. %s",
+                                         field["field"], field["description"])
                             valid = False
                         else:
-                            logger.warning("csv metadata.annotations.%s not defined. %s", field["field"], field["description"])
+                            logger.warning("csv metadata.annotations.%s not defined. %s",
+                                           field["field"], field["description"])
 
                 for field in spec_required_fields:
                     if field["field"] not in csv["spec"]:
                         if field["required"]:
-                            logger.error("csv spec.%s not defined. %s", field["field"], field["description"])
+                            logger.error("csv spec.%s not defined. %s",
+                                         field["field"], field["description"])
                             valid = False
                         else:
-                            logger.warning("csv spec.%s not defined. %s", field["field"], field["description"])
+                            logger.warning("csv spec.%s not defined. %s",
+                                           field["field"], field["description"])
 
         return valid
 
@@ -369,7 +381,9 @@ class ValidateCmd():
                     alm_kinds = get_alm_kinds(json.loads(annotations["alm-examples"]))
                     for crd in crds:
                         if crd["kind"] not in alm_kinds:
-                            logger.error("%s CRD does not have an entry in alm-examples - please add such an example CR.", crd["kind"])
+                            logger.error("%s CRD does not have an entry in "
+                                         "alm-examples - please add such an "
+                                         "example CR.", crd["kind"])
                             valid = False
                 else:
                     logger.error("You should have alm-examples for every owned CRD")
@@ -382,7 +396,8 @@ class ValidateCmd():
                 valid = False
             else:
                 if "name" not in provider or len(provider.keys()) != 1:
-                    logger.error("csv.spec.provider element should have a single field \"name\".")
+                    logger.error("csv.spec.provider element should "
+                                 "have a single field \"name\".")
                     valid = False
         else:
             logger.error("csv.spec.provider should contain a \"name\" field.")
@@ -392,7 +407,8 @@ class ValidateCmd():
         if isinstance(spec["maintainers"], (list,)):
             for maintainer in spec["maintainers"]:
                 if "name" not in maintainer or "email" not in maintainer:
-                    logger.error("csv.spec.maintainers element should contain both name and email")
+                    logger.error("csv.spec.maintainers element should contain "
+                                 "both name and email")
                     valid = False
                 else:
                     if not is_email(maintainer["email"]):
@@ -406,7 +422,8 @@ class ValidateCmd():
         if isinstance(spec["links"], (list,)):
             for link in spec["links"]:
                 if "name" not in link or "url" not in link:
-                    logger.error("csv.spec.links element should contain both name and url")
+                    logger.error("csv.spec.links element should contain "
+                                 "both name and url")
                     valid = False
                 else:
                     if not is_url(link["url"]):
@@ -418,12 +435,15 @@ class ValidateCmd():
 
         # version check
         if not is_version(spec["version"]):
-            logger.error("spec.version %s is not a valid version (example of a valid version is: v1.0.12)", spec["version"])
+            logger.error("spec.version %s is not a valid version "
+                         "(example of a valid version is: v1.0.12)",
+                         spec["version"])
             valid = False
 
         # capabilities check
         if not is_capability_level(annotations["capabilities"]):
-            logger.error("metadata.annotations.capabilities %s is not a valid capabilities level", annotations["capability"])
+            logger.error("metadata.annotations.capabilities %s is not a "
+                         "valid capabilities level", annotations["capability"])
             valid = False
 
         return valid

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ from setuptools import setup
 with open('README.md', 'r') as f:
     long_description = f.read()
 
+tests_require = [
+  'pytest',
+]
+
 setup(
   name='operator-courier',
   packages=['operatorcourier'],
@@ -22,7 +26,10 @@ setup(
     'validators'
   ],
   setup_requires=['pytest-runner'],
-  tests_require=['pytest'],
+  tests_require=tests_require,
+  extras_require={
+    'test': tests_require,
+  },
   long_description=long_description,
   long_description_content_type="text/markdown",
   license="Apache License 2.0",

--- a/setup.py
+++ b/setup.py
@@ -5,6 +5,7 @@ with open('README.md', 'r') as f:
 
 tests_require = [
   'pytest',
+  'pytest-cov'
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,8 @@ with open('README.md', 'r') as f:
 
 tests_require = [
   'pytest',
-  'pytest-cov'
+  'pytest-cov',
+  'testfixtures',
 ]
 
 setup(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 import pytest
 import yaml
 from operatorcourier import api

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,8 +3,10 @@ import yaml
 from operatorcourier import api
 from operatorcourier.format import unformat_bundle
 
+
 @pytest.mark.parametrize('directory,expected', [
-("tests/test_files/bundles/api/bundle1", "tests/test_files/bundles/api/bundle1/results/bundle.yaml"),
+    ("tests/test_files/bundles/api/bundle1",
+     "tests/test_files/bundles/api/bundle1/results/bundle.yaml"),
 ])
 def test_make_bundle(directory, expected):
     bundle = api.build_and_verify(source_dir=directory)
@@ -13,11 +15,16 @@ def test_make_bundle(directory, expected):
         expected_bundle = yaml.safe_load(expected_file)
         assert unformat_bundle(bundle) == unformat_bundle(expected_bundle)
 
+
 @pytest.mark.parametrize('yaml_files,expected', [
-(["tests/test_files/bundles/api/bundle1/crd.yml",
-"tests/test_files/bundles/api/bundle1/csv.yaml",
-"tests/test_files/bundles/api/bundle1/packages.yaml"],
-"tests/test_files/bundles/api/bundle1/results/bundle.yaml"),
+    (
+        [
+            "tests/test_files/bundles/api/bundle1/crd.yml",
+            "tests/test_files/bundles/api/bundle1/csv.yaml",
+            "tests/test_files/bundles/api/bundle1/packages.yaml"
+        ],
+        "tests/test_files/bundles/api/bundle1/results/bundle.yaml"
+    ),
 ])
 def test_make_bundle_with_yaml_list(yaml_files, expected):
     yamls = []

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -2,7 +2,11 @@ from operatorcourier.build import BuildCmd
 
 
 def test_create_bundle():
-    paths = ["tests/test_files/csv.yaml", "tests/test_files/crd.yaml", "tests/test_files/package.yaml"]
+    paths = [
+        "tests/test_files/csv.yaml",
+        "tests/test_files/crd.yaml",
+        "tests/test_files/package.yaml"
+    ]
     yamls = []
     for path in paths:
         with open(path) as f:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,5 +1,3 @@
-from unittest import TestCase
-import pytest
 from operatorcourier.build import BuildCmd
 
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -9,6 +9,6 @@ def test_create_bundle():
             yamls.append(f.read())
 
     bundle = BuildCmd().build_bundle(yamls)
-    assert bool(bundle["data"]["packages"]) == True
-    assert bool(bundle["data"]["clusterServiceVersions"]) == True
-    assert bool(bundle["data"]["customResourceDefinitions"]) == True
+    assert bool(bundle["data"]["packages"]) is True
+    assert bool(bundle["data"]["clusterServiceVersions"]) is True
+    assert bool(bundle["data"]["customResourceDefinitions"]) is True

--- a/tests/test_files/bundles/verification/no-data-key.bundle.yaml
+++ b/tests/test_files/bundles/verification/no-data-key.bundle.yaml
@@ -1,0 +1,3 @@
+DATA:
+  clusterServiceVersions: none
+  customResourceDefinitions: none

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -3,7 +3,6 @@ import operatorcourier.identify as identify
 from testfixtures import LogCapture
 
 
-
 @pytest.mark.parametrize('fname,expected', [
     ("tests/test_files/csv.yaml", "ClusterServiceVersion"),
     ("tests/test_files/crd.yaml", "CustomResourceDefinition"),
@@ -25,9 +24,9 @@ def test_get_operator_artifact_type_assertions(fname):
     with pytest.raises(ValueError) as e, LogCapture() as logs:
         identify.get_operator_artifact_type(yaml)
 
-    logs.check(
-        ('operatorcourier.identify', 'ERROR', 'Courier requires valid CSV, CRD, and Package files'),
-    )
+    logs.check(('operatorcourier.identify',
+                'ERROR',
+                'Courier requires valid CSV, CRD, and Package files'),)
     assert 'Courier requires valid CSV, CRD, and Package files' == str(e.value)
 
 
@@ -42,7 +41,7 @@ def test_get_operator_artifact_type_with_invalid_yaml(fname):
     with pytest.raises(ValueError) as e, LogCapture() as logs:
         identify.get_operator_artifact_type(yaml)
 
-    logs.check(
-        ('operatorcourier.identify', 'ERROR', 'Courier requires valid input YAML files'),
-    )
+    logs.check(('operatorcourier.identify',
+                'ERROR',
+                'Courier requires valid input YAML files'),)
     assert 'Courier requires valid input YAML files' == str(e.value)

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -1,4 +1,3 @@
-from unittest import TestCase
 import pytest
 import operatorcourier.identify as identify
 from testfixtures import LogCapture

--- a/tests/test_identify.py
+++ b/tests/test_identify.py
@@ -3,6 +3,7 @@ import operatorcourier.identify as identify
 from testfixtures import LogCapture
 
 
+
 @pytest.mark.parametrize('fname,expected', [
     ("tests/test_files/csv.yaml", "ClusterServiceVersion"),
     ("tests/test_files/crd.yaml", "CustomResourceDefinition"),
@@ -15,8 +16,8 @@ def test_get_operator_artifact_type(fname, expected):
 
 
 @pytest.mark.parametrize('fname', [
-    "tests/test_files/invalid.yaml",
-    "tests/test_files/empty.yaml",
+    ("tests/test_files/invalid.yaml"),
+    ("tests/test_files/empty.yaml"),
 ])
 def test_get_operator_artifact_type_assertions(fname):
     with open(fname) as f:

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -8,7 +8,6 @@ def test_nest_default():
     with TemporaryDirectory() as registry_dir:
         expected_result = "tests/test_files/bundles/nest/bundle1result"
         folder_to_nest = "tests/test_files/bundles/nest/bundle1"
-        expected_subfolders = [registry_dir + "/0.14.0", registry_dir + "/0.15.0", registry_dir + "/0.22.2"]
 
         yaml_files = []
         for filename in os.listdir(folder_to_nest):

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -3,6 +3,7 @@ from filecmp import dircmp
 from tempfile import TemporaryDirectory
 from operatorcourier.nest import nest_bundles
 
+
 def test_nest_default():
     with TemporaryDirectory() as registry_dir:
         expected_result = "tests/test_files/bundles/nest/bundle1result"
@@ -16,6 +17,6 @@ def test_nest_default():
 
         with TemporaryDirectory() as temp_dir:
             nest_bundles(yaml_files, registry_dir, temp_dir)
-        
+
         dcmp = dircmp(registry_dir, expected_result)
         assert(len(dcmp.diff_files) == 0)

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -1,6 +1,4 @@
 import os
-import pytest
-import yaml
 from filecmp import dircmp
 from tempfile import TemporaryDirectory
 from operatorcourier.nest import nest_bundles

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,4 +1,3 @@
-import pytest
 import yaml
 from operatorcourier.validate import ValidateCmd
 from operatorcourier.format import unformat_bundle

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -4,7 +4,10 @@ from operatorcourier.format import unformat_bundle
 
 
 def test_valid_bundles():
-    bundles = ["tests/test_files/bundles/verification/valid.bundle.yaml", "tests/test_files/bundles/verification/nocrd.valid.bundle.yaml"]
+    bundles = [
+        "tests/test_files/bundles/verification/valid.bundle.yaml",
+        "tests/test_files/bundles/verification/nocrd.valid.bundle.yaml"
+    ]
     for bundle in bundles:
         with open(bundle) as f:
             bundle = yaml.safe_load(f)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -10,7 +10,7 @@ def test_valid_bundles():
             bundle = yaml.safe_load(f)
             bundle = unformat_bundle(bundle)
             valid = ValidateCmd().validate(bundle)
-            assert valid == True
+            assert valid is True
 
 
 def test_invalid_bundle():
@@ -20,7 +20,8 @@ def test_invalid_bundle():
             bundle = yaml.safe_load(f)
             bundle = unformat_bundle(bundle)
             valid = ValidateCmd().validate(bundle)
-            assert valid == False
+            assert valid is False
+
 
 def test_ui_valid_bundle_io():
     bundles = ["tests/test_files/bundles/verification/valid.bundle.yaml"]
@@ -29,4 +30,4 @@ def test_ui_valid_bundle_io():
             bundle = yaml.safe_load(f)
             bundle = unformat_bundle(bundle)
             valid = ValidateCmd(ui_validate_io=True).validate(bundle)
-            assert valid == True
+            assert valid is True

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -17,7 +17,10 @@ def test_valid_bundles():
 
 
 def test_invalid_bundle():
-    bundles = ["tests/test_files/bundles/verification/nopkg.invalid.bundle.yaml"]
+    bundles = [
+        "tests/test_files/bundles/verification/nopkg.invalid.bundle.yaml",
+        "tests/test_files/bundles/verification/no-data-key.bundle.yaml",
+    ]
     for bundle in bundles:
         with open(bundle) as f:
             bundle = yaml.safe_load(f)

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -2,7 +2,6 @@ import yaml
 from operatorcourier.validate import ValidateCmd
 from operatorcourier.format import unformat_bundle
 
-#use same variable name twice!
 
 def test_valid_bundles():
     bundles = ["tests/test_files/bundles/verification/valid.bundle.yaml", "tests/test_files/bundles/verification/nocrd.valid.bundle.yaml"]
@@ -12,6 +11,7 @@ def test_valid_bundles():
             bundle = unformat_bundle(bundle)
             valid = ValidateCmd().validate(bundle)
             assert valid == True
+
 
 def test_invalid_bundle():
     bundles = ["tests/test_files/bundles/verification/nopkg.invalid.bundle.yaml"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37
+envlist = py36,py37,flake8
 
 [testenv]
 deps = .[test]
@@ -8,3 +8,13 @@ commands =
 
 [coverage:report]
 fail_under = 64
+
+[testenv:flake8]
+deps =
+    flake8
+skipdist = true
+skip_install = true
+commands = flake8 {posargs}
+
+[flake8]
+max-line-length = 90

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py36,py37
+
+[testenv]
+deps = .[test]
+commands =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,7 @@ envlist = py36,py37
 [testenv]
 deps = .[test]
 commands =
-    pytest
+    pytest --cov=operatorcourier {posargs}
+
+[coverage:report]
+fail_under = 64


### PR DESCRIPTION
This is a the first step to configure travis-ci to check PRs. 

By using [tox](https://tox.readthedocs.io/en/latest/index.html) we can make sure that travis-ci and developers run tests the same way, and helps avoiding the _works on my machine_ dilemma.

This PR also enables measuring code coverage, sets up code linting, and fixes the issues discovered by flake8.

Might be easier to review commit-by-commit.