### PR TITLE
Set up Travis CI and Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+sudo: false
+language: python
+matrix:
+  include:
+    - dist: trusty
+      python: "3.6"
+      env: TOXENV=py36
+      after_success: coveralls
+    - dist: xenial
+      python: "3.7"
+      env: TOXENV=py37
+      after_success: coveralls
+    - dist: xenial
+      python: "3.7"
+      env: TOXENV=flake8
+install: pip install tox-travis coveralls
+script: tox

--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -82,7 +82,7 @@ def build_verify_and_push(namespace, repository, revision, token,
     bundle = build_and_verify(source_dir, yamls, validation_output=validation_output)
 
     bundle = build_and_verify(source_dir, yamls)
-    
+
     with TemporaryDirectory() as temp_dir:
         with open('%s/bundle.yaml' % temp_dir, 'w') as outfile:
             yaml.dump(bundle, outfile, default_flow_style=False)

--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -40,7 +40,8 @@ These are the commands you can use:
             __version__ = 'unknown'
 
         parser.add_argument('command', help='Subcommand to run')
-        parser.add_argument('-v', '--version', help='Show the current version of operator-courier',
+        parser.add_argument('-v', '--version',
+                            help='Show the current version of operator-courier',
                             action='version', version=__version__)
 
         args = parser.parse_args(sys.argv[1:2])


### PR DESCRIPTION
Configuration for Travis CI: run tox and push results to Coveralls, in order to have updates about coverage, too, in PR checks.