### PR TITLE
Fix push validation

### DIFF
--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -81,8 +81,6 @@ def build_verify_and_push(namespace, repository, revision, token,
 
     bundle = build_and_verify(source_dir, yamls, validation_output=validation_output)
 
-    bundle = build_and_verify(source_dir, yamls)
-
     with TemporaryDirectory() as temp_dir:
         with open('%s/bundle.yaml' % temp_dir, 'w') as outfile:
             yaml.dump(bundle, outfile, default_flow_style=False)


### PR DESCRIPTION
Problem:
Due to a merge error, verify gets called twice on a push

Fix:
Remove extra bundle assignment in build_verify_and_push() api method