### PR TITLE
Remove unused "regex" module dependency

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,6 @@ requests = "*"
 pytest = "*"
 pyyaml = "*"
 twine = "*"
-regex = "*"
 
 
 [dev-packages]

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
   install_requires=[
     'pyyaml',
     'requests',
-    'regex',
     'validators'
   ],
   setup_requires=['pytest-runner'],


### PR DESCRIPTION
Commit e7c1842d4e487299e863b11bb33bcdf04686d5df introduced "regex"
dependency but this module is not used anywhere in code.

Only "re" module is used from python's stdlib

Signed-off-by: Martin Bašti <mbasti@redhat.com>