### PR TITLE
Move logging.basicConfig() from api to cli

### DIFF
--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -16,7 +16,6 @@ from operatorcourier.push import PushCmd
 from operatorcourier.format import format_bundle
 from operatorcourier.nest import nest_bundles
 
-logging.basicConfig()
 logger = logging.getLogger(__name__)
 
 

--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -1,12 +1,14 @@
 import argparse
 import pkg_resources
 import sys
+import logging
 from operatorcourier import api
 
 
 def main():
     """Generate the CLI bits
     """
+    logging.basicConfig()
     try:
         parser = _CliParser()
         parser.parse()


### PR DESCRIPTION
Logging should be set in the cli rather than the api to
avoid overwritting logging settings set by the user.

Fixes #58