### PR TITLE
The `push-to-quay` script support running on MACos

### DIFF
--- a/scripts/push-to-quay
+++ b/scripts/push-to-quay
@@ -21,7 +21,11 @@ trap cleanup EXIT
 
 tar czf ${FILENAME}.tar.gz ${FILENAME}.yaml
 
-BLOB=$(cat ${FILENAME}.tar.gz | base64 -w 0)
+if [ $(uname) == "Darwin" ];then
+    BLOB=$(cat ${FILENAME}.tar.gz | base64 -b 0)   
+else
+    BLOB=$(cat ${FILENAME}.tar.gz | base64 -w 0)
+fi
 
 curl -H "Content-Type: application/json" \
      -H "Authorization: ${TOKEN}" \


### PR DESCRIPTION
Support it for MAC, fixed below errors on MAC:
```console
base64: invalid option -- w
Usage:	base64 [-hvD] [-b num] [-i in_file] [-o out_file]
  -h, --help     display this message
  -D, --decode   decodes input
  -b, --break    break encoded string into num character lines
  -i, --input    input file (default: "-" for stdin)
  -o, --output   output file (default: "-" for stdout)
```