### PR TITLE
Fix: UI validation functions

### DIFF
--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -59,7 +59,7 @@ These are the commands you can use:
         parser.add_argument('source_dir', help='Path of your directory of yaml '
                             'files to bundle. Either set this or '
                             'use the files argument for bundle data.')
-        parser.add_argument('--ui_validate_io',
+        parser.add_argument('--ui-validate-io',
                             help='Validate bundle for operatorhub.io UI',
                             action='store_true')
         parser.add_argument('--validation-output', dest='validation_output',

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -373,14 +373,15 @@ class ValidateCmd():
         def is_version(field):
             pattern1 = re.compile(r'v(\d+\.)(\d+\.)(\d)')
             pattern2 = re.compile(r'(\d+\.)(\d+\.)(\d)')
-            return pattern1.match(field) or pattern2.match(field)
+            pattern3 = re.compile(r'(v)?(\d+\.)(\d+\.)(\d)(-[a-z0-9\-\.]+)?')
+            return pattern1.match(field) or pattern2.match(field) or pattern3.match(field)
 
         def is_capability_level(field):
             levels = [
                 "Basic Install",
                 "Seamless Upgrades",
                 "Full Lifecycle",
-                "Deep Insight",
+                "Deep Insights",
                 "Auto Pilot"
             ]
             return field in levels
@@ -467,7 +468,7 @@ class ValidateCmd():
         # capabilities check
         if not is_capability_level(annotations["capabilities"]):
             self._log_error("metadata.annotations.capabilities %s is not a "
-                            "valid capabilities level", annotations["capability"])
+                            "valid capabilities level", annotations["capabilities"])
             valid = False
 
         return valid


### PR DESCRIPTION
- Fix name of 'Deep Insights' capability
- Set key to 'capabilities' for error logging
- Add regex for alternate version format
- Change validation flag to use dashes instead of underscores

The first two issues I encountered when running the courier against
community-operators PRs.
The regex is important for versions that use a string after the
semver.
I also changed the validation CLI flag to use dashes as is the
convention for CLI flags. If using underscores was intended I can remove this change.