### PR TITLE
Fix: Expand regular expression for version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,12 +4,11 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-
 validators = "*"
 requests = "*"
 pytest = "*"
 pyyaml = "*"
 twine = "*"
-
+semver = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "18523475689e3183d2da8dfea9f6f6e55520811e8a2812d7415feb4738a08cc9"
+            "sha256": "5d7ac951678f5b9207ea989f0dc2e89ebecf9348d1558cebfa384e8635554890"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,10 +23,10 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
         },
         "bleach": {
             "hashes": [
@@ -37,10 +37,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -48,6 +48,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
         },
         "docutils": {
             "hashes": [
@@ -147,6 +154,14 @@
             ],
             "version": "==0.9.1"
         },
+        "semver": {
+            "hashes": [
+                "sha256:41c9aa26c67dc16c54be13074c352ab666bce1fa219c7110e8f03374cd4206b0",
+                "sha256:5b09010a66d9a3837211bb7ae5a20d10ba88f8cb49e92cb139a69ef90d5060d8"
+            ],
+            "index": "pypi",
+            "version": "==2.8.1"
+        },
         "six": {
             "hashes": [
                 "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
@@ -175,6 +190,13 @@
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
             "version": "==1.24.1"
+        },
+        "validators": {
+            "hashes": [
+                "sha256:68e4b74889aac1270d83636cb1dbcce3d2271e291ab14023cf95e7dbfbbce09d"
+            ],
+            "index": "pypi",
+            "version": "==0.12.4"
         },
         "webencodings": {
             "hashes": [

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -1,6 +1,6 @@
 import logging
 import json
-import re
+import semver
 
 import validators as v
 
@@ -386,9 +386,11 @@ class ValidateCmd():
             return True
 
         def is_version(field):
-            pattern1 = re.compile(r'v(\d+\.)(\d+\.)(\d)')
-            pattern2 = re.compile(r'(\d+\.)(\d+\.)(\d)')
-            return pattern1.match(field) or pattern2.match(field)
+            try:
+                semver.parse(field)
+            except ValueError:
+                return False
+            return True
 
         def is_capability_level(field):
             levels = [
@@ -494,8 +496,8 @@ class ValidateCmd():
 
         # version check
         if not is_version(spec["version"]):
-            self._log_error("spec.version %s is not a valid version "
-                            "(example of a valid version is: v1.0.12)",
+            self._log_error("spec.version %s is not a valid semver "
+                            "(example of a valid semver is: 1.0.12)",
                             spec["version"])
             valid = False
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,8 @@ setup(
   install_requires=[
     'pyyaml',
     'requests',
-    'validators'
+    'validators',
+    'semver'
   ],
   python_requires='>=3.6, <4',
   setup_requires=['pytest-runner'],

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -50,8 +50,8 @@ def test_ui_valid_bundle_io(bundle, expected_validation_results_dict):
         ("tests/test_files/bundles/verification/ui.invalid.bundle.yaml",
             {'errors': [
                 "csv.spec.links must be a list of name & url pairs.",
-                "spec.version invalid is not a valid version "
-                "(example of a valid version is: v1.0.12)",
+                "spec.version invalid is not a valid semver "
+                "(example of a valid semver is: 1.0.12)",
                 "metadata.annotations.capabilities invalid "
                 "is not a valid capabilities level",
                 "spec.icon[0].mediatype image/invalid is not "


### PR DESCRIPTION
- Combined regex patterns
- Added optional version suffix

This adds support for versions that use a string after the semver.
Replaces #65 