### PR TITLE
Update Travis CI config to test courier on macOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,36 @@ matrix:
       python: "3.7"
       env: TOXENV=py37
       after_success: coveralls
+    - os: osx
+      language: generic
+      env:
+        - PYTHON=3.6.0
+        - TOXENV=py36
+    - os: osx
+      language: generic
+      env:
+        - PYTHON=3.7.0
+        - TOXENV=py37
     - dist: xenial
       python: "3.7"
       env: TOXENV=flake8
+
+# Installing Python on macOS for Travis CI: https://pythonhosted.org/CodeChat/.travis.yml.html
+before_install: |
+  if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+    brew update
+    brew install openssl readline
+    brew outdated pyenv || brew upgrade pyenv
+
+    brew install pyenv-virtualenv
+    pyenv install $PYTHON
+
+    export PYENV_VERSION=$PYTHON
+    export PATH="/Users/travis/.pyenv/shims:${PATH}"
+    pyenv-virtualenv venv
+    source venv/bin/activate
+
+    python --version
+  fi
 install: pip install tox-travis coveralls
 script: tox


### PR DESCRIPTION
Build operator-courier on macOS with Travis CI.

Because testing Python projects on macOS is not natively supported by Travis CI, I use a [workaround](https://pythonhosted.org/CodeChat/.travis.yml.html) to make it happen. Finishing tests on macOS with Travis CI will take around 10min, due to the time-consuming `brew update` and `brew install` operations.