### PR TITLE
Add basic integration tests with behave

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ requests = "*"
 pytest = "*"
 pyyaml = "*"
 twine = "*"
+behave = "*"
 
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "18523475689e3183d2da8dfea9f6f6e55520811e8a2812d7415feb4738a08cc9"
+            "sha256": "a02ace079a041bd25f7a7bfd554c09da8490446994c4425d0be67a6219ae76d3"
         },
         "pipfile-spec": 6,
         "requires": {},
@@ -23,10 +23,18 @@
         },
         "attrs": {
             "hashes": [
-                "sha256:10cbf6e27dbce8c30807caf056c8eb50917e0eaafe86347671b57254006c3e69",
-                "sha256:ca4be454458f9dec299268d472aaa5a11f67a4ff70093396e1ceae9c76cf4bbb"
+                "sha256:69c0dbf2ed392de1cb5ec704444b08a5ef81680a61cb899dc08127123af36a79",
+                "sha256:f0b870f674851ecbfbbbd364d6b5cbdff9dcedbc7f3f5e18a6891057f21fe399"
             ],
-            "version": "==18.2.0"
+            "version": "==19.1.0"
+        },
+        "behave": {
+            "hashes": [
+                "sha256:b9662327aa53294c1351b0a9c369093ccec1d21026f050c3bd9b3e5cccf81a86",
+                "sha256:ebda1a6c9e5bfe95c5f9f0a2794e01c7098b3dde86c10a95d8621c5907ff6f1c"
+            ],
+            "index": "pypi",
+            "version": "==1.2.6"
         },
         "bleach": {
             "hashes": [
@@ -37,10 +45,10 @@
         },
         "certifi": {
             "hashes": [
-                "sha256:47f9c83ef4c0c621eaef743f133f09fa8a74a9b75f037e8624f83bd1b6626cb7",
-                "sha256:993f830721089fef441cdfeb4b2c8c9df86f0c63239f06bd025a76a7daddb033"
+                "sha256:59b7658e26ca9c7339e00f8f4636cdfe59d34fa37b9b04f6f9e9926b3cece1a5",
+                "sha256:b26104d6835d1f5e49452a26eb2ff87fe7090b89dfcaee5ea2212697e1e1d7ae"
             ],
-            "version": "==2018.11.29"
+            "version": "==2019.3.9"
         },
         "chardet": {
             "hashes": [
@@ -48,6 +56,13 @@
                 "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"
             ],
             "version": "==3.0.4"
+        },
+        "decorator": {
+            "hashes": [
+                "sha256:86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de",
+                "sha256:f069f3a01830ca754ba5258fde2278454a0b5b79e0d7f5c13b3b97e57d4acff6"
+            ],
+            "version": "==4.4.0"
         },
         "docutils": {
             "hashes": [
@@ -71,6 +86,19 @@
             ],
             "markers": "python_version > '2.7'",
             "version": "==6.0.0"
+        },
+        "parse": {
+            "hashes": [
+                "sha256:870dd675c1ee8951db3e29b81ebe44fd131e3eb8c03a79483a58ea574f3145c2"
+            ],
+            "version": "==1.11.1"
+        },
+        "parse-type": {
+            "hashes": [
+                "sha256:6e906a66f340252e4c324914a60d417d33a4bea01292ea9bbf68b4fc123be8c9",
+                "sha256:f596bdc75d3dd93036fbfe3d04127da9f6df0c26c36e01e76da85adef4336b3c"
+            ],
+            "version": "==0.4.2"
         },
         "pkginfo": {
             "hashes": [
@@ -102,28 +130,28 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:067a1d4bf827ffdd56ad21bd46674703fce77c5957f6c1eef731f6146bfcef1c",
-                "sha256:9687049d53695ad45cf5fdc7bbd51f0c49f1ea3ecfc4b7f3fde7501b541f17f4"
+                "sha256:592eaa2c33fae68c7d75aacf042efc9f77b27c08a6224a4f59beab8d9a420523",
+                "sha256:ad3ad5c450284819ecde191a654c09b0ec72257a2c711b9633d677c71c9850c4"
             ],
             "index": "pypi",
-            "version": "==4.3.0"
+            "version": "==4.3.1"
         },
         "pyyaml": {
             "hashes": [
-                "sha256:3d7da3009c0f3e783b2c873687652d83b1bbfd5c88e9813fb7e5b03c0dd3108b",
-                "sha256:3ef3092145e9b70e3ddd2c7ad59bdd0252a94dfe3949721633e41344de00a6bf",
-                "sha256:40c71b8e076d0550b2e6380bada1f1cd1017b882f7e16f09a65be98e017f211a",
-                "sha256:558dd60b890ba8fd982e05941927a3911dc409a63dcb8b634feaa0cda69330d3",
-                "sha256:a7c28b45d9f99102fa092bb213aa12e0aaf9a6a1f5e395d36166639c1f96c3a1",
-                "sha256:aa7dd4a6a427aed7df6fb7f08a580d68d9b118d90310374716ae90b710280af1",
-                "sha256:bc558586e6045763782014934bfaf39d48b8ae85a2713117d16c39864085c613",
-                "sha256:d46d7982b62e0729ad0175a9bc7e10a566fc07b224d2c79fafb5e032727eaa04",
-                "sha256:d5eef459e30b09f5a098b9cea68bebfeb268697f78d647bd255a085371ac7f3f",
-                "sha256:e01d3203230e1786cd91ccfdc8f8454c8069c91bee3962ad93b87a4b2860f537",
-                "sha256:e170a9e6fcfd19021dd29845af83bb79236068bf5fd4df3327c1be18182b2531"
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
             ],
             "index": "pypi",
-            "version": "==3.13"
+            "version": "==5.1"
         },
         "readme-renderer": {
             "hashes": [
@@ -175,6 +203,13 @@
                 "sha256:de9529817c93f27c8ccbfead6985011db27bd0ddfcdb2d86f3f663385c6a9c22"
             ],
             "version": "==1.24.1"
+        },
+        "validators": {
+            "hashes": [
+                "sha256:68e4b74889aac1270d83636cb1dbcce3d2271e291ab14023cf95e7dbfbbce09d"
+            ],
+            "index": "pypi",
+            "version": "==0.12.4"
         },
         "webencodings": {
             "hashes": [

--- a/features/environment.py
+++ b/features/environment.py
@@ -1,0 +1,21 @@
+from subprocess import check_call
+
+
+def before_tag(context, tag):
+    if tag == 'cli':
+        commands = [
+            'make release',
+            'pip install dist/operator_courier-*-none-any.whl',
+            'operator-courier -v',
+        ]
+
+        for command in commands:
+            exit_code = check_call(command, shell=True)
+            assert exit_code == 0
+
+
+def after_tag(context, tag):
+    if tag == 'cli':
+        cmd = 'make clean'
+        exit_code = check_call(cmd, shell=True)
+        assert exit_code == 0

--- a/features/steps/verify.py
+++ b/features/steps/verify.py
@@ -1,0 +1,28 @@
+from behave import step, use_step_matcher
+import subprocess
+
+use_step_matcher("re")
+
+
+@step('operator-courier should be able to verify the VALID input yaml files '
+      'in the input directory "(?P<source_dir>.+)"')
+def test_verify_the_valid_input_yaml_files_in_the_input_directory(context, source_dir):
+    cmd = f'operator-courier verify {source_dir}'
+    exit_code = subprocess.check_call(cmd, shell=True)
+    assert exit_code == 0
+
+
+@step(
+    'operator-courier should verify that the input yaml files in the input directory '
+    '"(?P<source_dir>.+)" is invalid, return a non-zero status, '
+    'and log error messages that contain "(?P<error_message>.+)"')
+def step_impl(context, source_dir, error_message):
+    process = subprocess.Popen(f'operator-courier verify {source_dir}',
+                               shell=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
+    exit_code = process.wait()
+    assert exit_code != 0
+
+    outputs = process.stdout.read().decode("utf-8")
+    assert error_message in outputs

--- a/features/steps/yamls_for_bundle/invalid_yamls_without_package/dynatrace-monitoring.v0.2.0.clusterserviceversion.yaml
+++ b/features/steps/yamls_for_bundle/invalid_yamls_without_package/dynatrace-monitoring.v0.2.0.clusterserviceversion.yaml
@@ -1,0 +1,249 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [{
+       "apiVersion": "dynatrace.com/v1alpha1",
+       "kind": "OneAgent",
+       "metadata": {
+          "name": "oneagent",
+          "namespace": "dynatrace"
+       },
+       "spec": {
+          "apiUrl": "https://ENVIRONMENTID.live.dynatrace.com/api",
+          "skipCertCheck": false,
+          "tokens": "",
+          "nodeSelector": {},
+          "tolerations": [
+             {
+                "effect": "NoSchedule",
+                "key": "node-role.kubernetes.io/master",
+                "operator": "Exists"
+             }
+          ],
+          "image": "",
+          "args": [
+             "APP_LOG_CONTENT_ACCESS=1"
+          ],
+          "env": []
+       }
+      }]
+    categories: "Monitoring,OpenShift Optional"
+    certified: "false"
+    containerImage: quay.io/dynatrace/dynatrace-oneagent-operator:v0.2.0
+    createdAt: 2019-02-06T12:59:59Z
+    description: Install full-stack monitoring of Kubernetes clusters with the Dynatrace OneAgent.
+    support: Dynatrace
+  name: dynatrace-monitoring.v0.2.0
+  namespace: "placeholder"
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: Dyantrace OneAgent monitoring agent
+        displayName: Dynatrace OneAgent
+        kind: OneAgent
+        name: oneagents.dynatrace.com
+        resources:
+          - kind: DaemonSet
+            name: ""
+            version: v1beta2
+          - kind: Pod
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: Credentials for the OneAgent to connect back to Dynatrace.
+            displayName: API and Pass Tokens
+            path: tokens
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+          - description: 'Location of the Dynatrace API to connect to, including your specific environment ID'
+            displayName: API URL
+            path: apiUrl
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Specifies if certificate checks should be skipped.
+            displayName: Skip Certificate Check
+            path: skipCertCheck
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:booleanCheck'
+          - description: Node selector for where pods should be scheduled.
+            displayName: Node Selector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Node'
+          - description: The Dynatrace installer container image.
+            displayName: Image
+            path: image
+          - description: Define resources requests and limits for single Pods
+            displayName: Resource Requirements
+            path: resources
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+        statusDescriptors:
+          - description: Dynatrace version being used.
+            displayName: Version
+            path: version
+          - description: The timestamp when the instance was last updated.
+            displayName: Last Updated
+            path: updatedTimestamp
+            x-descriptors:
+              - 'urn:alm:descriptor:timestamp'
+        version: v1alpha1
+  description: |
+    Install full-stack monitoring of [Kubernetes clusters](https://www.dynatrace.com/technologies/kubernetes-monitoring/) with the Dynatrace OneAgent on your cluster. OneAgent connects back to Dynatrace's hosted monitoring tools.
+
+    ### Before Your Start
+
+    Add a Secret within the Project that contians your API and PaaS tokens.  Create tokens of type *Dynatrace API* (`API_TOKEN`) and *Platform as a Service* (`PAAS_TOKEN`) and use its values in the following commands respectively.  For assistance please refere to [Create user-generated access
+    tokens](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens).
+
+        $ kubectl -n dynatrace create secret generic oneagent --from-literal="apiToken=API_TOKEN" --from-literal="paasToken=PAAS_TOKEN"
+
+    You may update this Secret at any time to rotate the tokens.
+
+    ### Required Parameters
+
+    * `apiUrl` - provide the environment ID used in conjuction with this monitoring agent in the API adddress, eg `https://<ENVIRONMENTID>.live.dynatrace.com/api`
+
+    ### Advanced Options
+
+    **Image Override** - use a copy of the OneAgent container image from a registry other than Quay`s or Red Hat's
+
+    **NodeSelectors** - select a subset of your cluster's Nodes to run OneAgent on, based on labels
+
+    **Tolerations** - add specific tolerations to the agent so that it can monitor all of the Nodes in your cluster; we include the default toleration so that dynatrace also monitors the master nodes.
+
+    **Disable Certificate Checking** - disable any certificate validation that may interact poorly with proxies with in your cluster
+
+    For a complete list of supported parameters please consult the [Operator Deploy Guide](https://www.dynatrace.com/support/help/shortlink/openshift-deploy#parameters).
+  displayName: Dynatrace OneAgent
+  install:
+    spec:
+      deployments:
+        - name: dynatrace-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: dynatrace-oneagent-operator
+            template:
+              metadata:
+                labels:
+                  dynatrace: operator
+                  name: dynatrace-oneagent-operator
+                  operator: oneagent
+              spec:
+                containers:
+                  - command:
+                      - dynatrace-oneagent-operator
+                    env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: quay.io/dynatrace/dynatrace-oneagent-operator:v0.2.0
+                    imagePullPolicy: Always
+                    name: dynatrace-oneagent-operator
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 128Mi
+                      requests:
+                        cpu: 100m
+                        memory: 64Mi
+                nodeSelector:
+                  beta.kubernetes.io/os: linux
+                serviceAccountName: dynatrace-oneagent-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - dynatrace.com
+              resources:
+                - oneagents
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - dynatrace.com
+              resources:
+                - oneagents/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - extensions
+              resources:
+                - podsecuritypolicies
+              resourceNames:
+                - dynatrace-oneagent-operator
+              verbs:
+                - use
+          serviceAccountName: dynatrace-oneagent-operator
+        - rules:
+            - apiGroups:
+                - extensions
+              resources:
+                - podsecuritypolicies
+              resourceNames:
+                - dynatrace-oneagent
+              verbs:
+                - use
+          serviceAccountName: dynatrace-oneagent
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - monitoring
+    - dynatrace
+    - oneagent
+  links:
+    - name: Operator Deploy Guide
+      url: https://www.dynatrace.com/support/help/shortlink/kubernetes-deploy
+    - name: Kubernetes Monitoring Info
+      url: https://www.dynatrace.com/technologies/kubernetes-monitoring/
+  maintainers:
+    - email: support@dynatrace.com
+      name: Dynatrace LLC
+  maturity: alpha
+  provider:
+    name: Dynatrace LLC
+  version: 0.2.0

--- a/features/steps/yamls_for_bundle/invalid_yamls_without_package/dynatrace.crd.yaml
+++ b/features/steps/yamls_for_bundle/invalid_yamls_without_package/dynatrace.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: oneagents.dynatrace.com
+spec:
+  group: dynatrace.com
+  names:
+    kind: OneAgent
+    listKind: OneAgentList
+    plural: oneagents
+    singular: oneagent
+  scope: Namespaced
+  version: v1alpha1

--- a/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/crd.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/crd.yaml
@@ -1,0 +1,54 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: catalogsourceconfigs.marketplace.redhat.com
+  annotations:
+    displayName: Catalog Source Config
+    description: Represents a CatalogSourceConfig.
+spec:
+  group: marketplace.redhat.com
+  names:
+    kind: CatalogSourceConfig
+    listKind: CatalogSourceConfigList
+    plural: catalogsourceconfigs
+    singular: catalogsourceconfig
+    shortNames:
+    - csc
+  scope: Namespaced
+  version: v1alpha1
+  additionalPrinterColumns:
+  - name: TargetNamespace
+    type: string
+    description: The namespace where the operators will be enabled
+    JSONPath: .spec.targetNamespace
+  - name: Packages
+    type: string
+    description: List of operator(s) which will be enabled in the target namespace
+    JSONPath: .spec.packages
+  - name: Status
+    type: string
+    description: Current status of the CatalogSourceConfig
+    JSONPath: .status.currentPhase.phase.name
+  - name: Message
+    type: string
+    description: Message associated with the current status
+    JSONPath: .status.currentPhase.phase.message
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for a CatalogSourceConfig
+          required:
+          - targetNamespace
+          - packages
+          properties:
+            targetNamespace:
+              type: string
+              description: The namespace where the operators will be enabled
+            packages:
+              type: string
+              description: Comma separated list of operator(s) without spaces which will be enabled in the target namespace

--- a/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/crd2.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/crd2.yaml
@@ -1,0 +1,74 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: operatorsources.marketplace.redhat.com
+  annotations:
+    displayName: Operator Source
+    description: Represents an OperatorSource.
+spec:
+  group: marketplace.redhat.com
+  names:
+    kind: OperatorSource
+    listKind: OperatorSourceList
+    plural: operatorsources
+    singular: operatorsource
+    shortNames:
+    - opsrc
+  scope: Namespaced
+  version: v1alpha1
+  additionalPrinterColumns:
+  - name: Type
+    type: string
+    description: The type of the OperatorSource
+    JSONPath: .spec.type
+  - name: Endpoint
+    type: string
+    description: The endpoint of the OperatorSource
+    JSONPath: .spec.endpoint
+  - name: Registry
+    type: string
+    description: App registry namespace
+    JSONPath: .spec.registryNamespace
+  - name: DisplayName
+    type: string
+    description: Display (pretty) name to indicate the OperatorSource's name
+    JSONPath: .spec.displayName
+  - name: Publisher
+    type: string
+    description: Publisher of the OperatorSource
+    JSONPath: .spec.publisher
+  - name: Status
+    type: string
+    description: Current status of the OperatorSource
+    JSONPath: .status.currentPhase.phase.name
+  - name: Message
+    type: string
+    description: Message associated with the current status
+    JSONPath: .status.currentPhase.phase.message
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
+  validation:
+    openAPIV3Schema:
+      properties:
+        spec:
+          type: object
+          description: Spec for an OperatorSource.
+          required:
+          - type
+          - endpoint
+          - registryNamespace
+          properties:
+            type:
+              type: string
+              description: The type of the OperatorSource
+              pattern: 'appregistry'
+            endpoint:
+              type: string
+              description: Points to the remote app registry server from where operator manifests can be fetched.
+            registryNamespace:
+              type: string
+              description: |-
+                The namespace in app registry.
+                Only operator manifests under this namespace will be visible.
+                Please note that this is not a k8s namespace.

--- a/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/csv.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/csv.yaml
@@ -1,0 +1,157 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: marketplace-operator.v0.0.1
+  namespace: placeholder
+  annotations:
+    categories: openshift required
+    certified: 'true'
+    containerImage: quay.io/openshift/origin-operator-marketplace:latest
+    createdAt: 2018-08-01T08:00:00Z
+    description: An operator to run the OpenShift marketplace
+    healthIndex: B
+    repository: https://github.com/operator-framework/operator-marketplace
+    support: Red Hat
+    alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+spec:
+  displayName: marketplace-operator
+  description: |-
+    Marketplace is a gateway for users to consume off-cluster Operators which will include Red Hat, ISV, optional OpenShift and community content.
+  keywords: ['marketplace', 'catalog', 'olm', 'admin']
+  version: 0.0.1
+  maturity: alpha
+  maintainers:
+  - name: AOS Marketplace Team
+    email: aos-marketplace@redhat.com
+  provider:
+    name: Red Hat
+  labels:
+    name: marketplace-operator
+  selector:
+    matchLabels:
+      name: marketplace-operator
+  links:
+  - name: Markplace Operator Source Code
+    url: https://github.com/operator-framework/operator-marketplace
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+  install:
+    strategy: deployment
+    spec:
+      clusterPermissions:
+      - serviceAccountName: marketplace-operator
+        rules:
+        - apiGroups:
+          - marketplace.redhat.com
+          resources:
+          - "*"
+          verbs:
+          - "*"
+        - apiGroups:
+          - ""
+          resources:
+          - services
+          - configmaps
+          verbs:
+          - "*"
+        - apiGroups:
+          - operators.coreos.com
+          resources:
+          - catalogsources
+          verbs:
+          - "*"
+      deployments:
+      - name: marketplace-operator
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              name: marketplace-operator
+          template:
+            metadata:
+              name: marketplace-operator
+              labels:
+                name: marketplace-operator
+            spec:
+              serviceAccountName: marketplace-operator
+              containers:
+                - name: marketplace-operator
+                  image: quay.io/openshift/origin-operator-marketplace:latest
+                  ports:
+                  - containerPort: 60000
+                    name: metrics
+                  - containerPort: 8080
+                    name: healthz
+                  command:
+                  - marketplace-operator
+                  imagePullPolicy: Always
+                  livenessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8080
+                  readinessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8080
+                  env:
+                    - name: WATCH_NAMESPACE
+                      valueFrom:
+                        fieldRef:
+                          fieldPath: metadata.namespace
+                    - name: OPERATOR_NAME
+                      value: "marketplace-operator"
+  customresourcedefinitions:
+    owned:
+    - name: operatorsources.marketplace.redhat.com
+      version: v1alpha1
+      kind: OperatorSource
+      displayName: Operator Source
+      description: Represents an OperatorSource.
+      specDescriptors: 
+        - description: The type of the operator source.
+          displayName: Type
+          path: type
+        - description: Points to the remote app registry server from where operator manifests can be fetched.
+          displayName: Endpoint
+          path: endpoint
+        - description: |-
+            The namespace in app registry.
+            Only operator manifests under this namespace will be visible.
+            Please note that this is not a k8s namespace.
+          displayName: Registry Namespace
+          path: registryNamespace
+      statusDescriptors:
+        - description: Current status of the CatalogSourceConfig
+          displayName: Current Phase Name
+          path: currentPhase.phase.name
+        - description: Message associated with the current status
+          displayName: Current Phase Message
+          path: currentPhase.phase.message
+    - name: catalogsourceconfigs.marketplace.redhat.com
+      version: v1alpha1
+      kind: CatalogSourceConfig
+      displayName: Catalog Source Config
+      description: Represents a CatalogSourceConfig object which is used to configure a CatalogSource.
+      specDescriptors:
+        - description: The namespace where the operators will be enabled.
+          displayName: Target Namespace
+          path: targetNamespace
+        - description: List of operator(s) which will be enabled in the target namespace
+          displayName: Packages
+          path: packages
+      statusDescriptors:
+        - description: Current status of the CatalogSourceConfig
+          displayName: Current Phase Name
+          path: currentPhase.phase.name
+        - description: Message associated with the current status
+          displayName: Current Phase Message
+          path: currentPhase.phase.message

--- a/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/package.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds/package.yaml
@@ -1,0 +1,5 @@
+#! package-manifest: deploy/chart/catalog_resources/rh-operators/marketplace.v0.0.1.clusterserviceversion.yaml
+packageName: marketplace
+channels:
+- name: alpha
+  currentCSV: marketplace-operator.v0.0.1

--- a/features/steps/yamls_for_bundle/valid_yamls_with_single_crd/dynatrace-monitoring.v0.2.0.clusterserviceversion.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_single_crd/dynatrace-monitoring.v0.2.0.clusterserviceversion.yaml
@@ -1,0 +1,249 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    alm-examples: |-
+      [{
+       "apiVersion": "dynatrace.com/v1alpha1",
+       "kind": "OneAgent",
+       "metadata": {
+          "name": "oneagent",
+          "namespace": "dynatrace"
+       },
+       "spec": {
+          "apiUrl": "https://ENVIRONMENTID.live.dynatrace.com/api",
+          "skipCertCheck": false,
+          "tokens": "",
+          "nodeSelector": {},
+          "tolerations": [
+             {
+                "effect": "NoSchedule",
+                "key": "node-role.kubernetes.io/master",
+                "operator": "Exists"
+             }
+          ],
+          "image": "",
+          "args": [
+             "APP_LOG_CONTENT_ACCESS=1"
+          ],
+          "env": []
+       }
+      }]
+    categories: "Monitoring,OpenShift Optional"
+    certified: "false"
+    containerImage: quay.io/dynatrace/dynatrace-oneagent-operator:v0.2.0
+    createdAt: 2019-02-06T12:59:59Z
+    description: Install full-stack monitoring of Kubernetes clusters with the Dynatrace OneAgent.
+    support: Dynatrace
+  name: dynatrace-monitoring.v0.2.0
+  namespace: "placeholder"
+spec:
+  apiservicedefinitions: {}
+  customresourcedefinitions:
+    owned:
+      - description: Dyantrace OneAgent monitoring agent
+        displayName: Dynatrace OneAgent
+        kind: OneAgent
+        name: oneagents.dynatrace.com
+        resources:
+          - kind: DaemonSet
+            name: ""
+            version: v1beta2
+          - kind: Pod
+            name: ""
+            version: v1
+        specDescriptors:
+          - description: Credentials for the OneAgent to connect back to Dynatrace.
+            displayName: API and Pass Tokens
+            path: tokens
+            x-descriptors:
+              - 'urn:alm:descriptor:io.kubernetes:core:v1:Secret'
+          - description: 'Location of the Dynatrace API to connect to, including your specific environment ID'
+            displayName: API URL
+            path: apiUrl
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:label'
+          - description: Specifies if certificate checks should be skipped.
+            displayName: Skip Certificate Check
+            path: skipCertCheck
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:booleanCheck'
+          - description: Node selector for where pods should be scheduled.
+            displayName: Node Selector
+            path: nodeSelector
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:selector:core:v1:Node'
+          - description: The Dynatrace installer container image.
+            displayName: Image
+            path: image
+          - description: Define resources requests and limits for single Pods
+            displayName: Resource Requirements
+            path: resources
+            x-descriptors:
+              - 'urn:alm:descriptor:com.tectonic.ui:resourceRequirements'
+        statusDescriptors:
+          - description: Dynatrace version being used.
+            displayName: Version
+            path: version
+          - description: The timestamp when the instance was last updated.
+            displayName: Last Updated
+            path: updatedTimestamp
+            x-descriptors:
+              - 'urn:alm:descriptor:timestamp'
+        version: v1alpha1
+  description: |
+    Install full-stack monitoring of [Kubernetes clusters](https://www.dynatrace.com/technologies/kubernetes-monitoring/) with the Dynatrace OneAgent on your cluster. OneAgent connects back to Dynatrace's hosted monitoring tools.
+
+    ### Before Your Start
+
+    Add a Secret within the Project that contians your API and PaaS tokens.  Create tokens of type *Dynatrace API* (`API_TOKEN`) and *Platform as a Service* (`PAAS_TOKEN`) and use its values in the following commands respectively.  For assistance please refere to [Create user-generated access
+    tokens](https://www.dynatrace.com/support/help/get-started/introduction/why-do-i-need-an-access-token-and-an-environment-id/#create-user-generated-access-tokens).
+
+        $ kubectl -n dynatrace create secret generic oneagent --from-literal="apiToken=API_TOKEN" --from-literal="paasToken=PAAS_TOKEN"
+
+    You may update this Secret at any time to rotate the tokens.
+
+    ### Required Parameters
+
+    * `apiUrl` - provide the environment ID used in conjuction with this monitoring agent in the API adddress, eg `https://<ENVIRONMENTID>.live.dynatrace.com/api`
+
+    ### Advanced Options
+
+    **Image Override** - use a copy of the OneAgent container image from a registry other than Quay`s or Red Hat's
+
+    **NodeSelectors** - select a subset of your cluster's Nodes to run OneAgent on, based on labels
+
+    **Tolerations** - add specific tolerations to the agent so that it can monitor all of the Nodes in your cluster; we include the default toleration so that dynatrace also monitors the master nodes.
+
+    **Disable Certificate Checking** - disable any certificate validation that may interact poorly with proxies with in your cluster
+
+    For a complete list of supported parameters please consult the [Operator Deploy Guide](https://www.dynatrace.com/support/help/shortlink/openshift-deploy#parameters).
+  displayName: Dynatrace OneAgent
+  install:
+    spec:
+      deployments:
+        - name: dynatrace-operator
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                name: dynatrace-oneagent-operator
+            template:
+              metadata:
+                labels:
+                  dynatrace: operator
+                  name: dynatrace-oneagent-operator
+                  operator: oneagent
+              spec:
+                containers:
+                  - command:
+                      - dynatrace-oneagent-operator
+                    env:
+                      - name: MY_POD_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    image: quay.io/dynatrace/dynatrace-oneagent-operator:v0.2.0
+                    imagePullPolicy: Always
+                    name: dynatrace-oneagent-operator
+                    resources:
+                      limits:
+                        cpu: 200m
+                        memory: 128Mi
+                      requests:
+                        cpu: 100m
+                        memory: 64Mi
+                nodeSelector:
+                  beta.kubernetes.io/os: linux
+                serviceAccountName: dynatrace-oneagent-operator
+      permissions:
+        - rules:
+            - apiGroups:
+                - dynatrace.com
+              resources:
+                - oneagents
+              verbs:
+                - get
+                - list
+                - watch
+                - update
+            - apiGroups:
+                - apps
+              resources:
+                - daemonsets
+              verbs:
+                - get
+                - list
+                - watch
+                - create
+                - update
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - configmaps
+                - pods
+              verbs:
+                - get
+                - list
+                - watch
+                - delete
+            - apiGroups:
+                - ""
+              resources:
+                - secrets
+              verbs:
+                - get
+                - list
+                - watch
+            - apiGroups:
+                - dynatrace.com
+              resources:
+                - oneagents/finalizers
+              verbs:
+                - update
+            - apiGroups:
+                - extensions
+              resources:
+                - podsecuritypolicies
+              resourceNames:
+                - dynatrace-oneagent-operator
+              verbs:
+                - use
+          serviceAccountName: dynatrace-oneagent-operator
+        - rules:
+            - apiGroups:
+                - extensions
+              resources:
+                - podsecuritypolicies
+              resourceNames:
+                - dynatrace-oneagent
+              verbs:
+                - use
+          serviceAccountName: dynatrace-oneagent
+    strategy: deployment
+  installModes:
+    - supported: true
+      type: OwnNamespace
+    - supported: true
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: false
+      type: AllNamespaces
+  keywords:
+    - monitoring
+    - dynatrace
+    - oneagent
+  links:
+    - name: Operator Deploy Guide
+      url: https://www.dynatrace.com/support/help/shortlink/kubernetes-deploy
+    - name: Kubernetes Monitoring Info
+      url: https://www.dynatrace.com/technologies/kubernetes-monitoring/
+  maintainers:
+    - email: support@dynatrace.com
+      name: Dynatrace LLC
+  maturity: alpha
+  provider:
+    name: Dynatrace LLC
+  version: 0.2.0

--- a/features/steps/yamls_for_bundle/valid_yamls_with_single_crd/dynatrace.crd.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_single_crd/dynatrace.crd.yaml
@@ -1,0 +1,13 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: oneagents.dynatrace.com
+spec:
+  group: dynatrace.com
+  names:
+    kind: OneAgent
+    listKind: OneAgentList
+    plural: oneagents
+    singular: oneagent
+  scope: Namespaced
+  version: v1alpha1

--- a/features/steps/yamls_for_bundle/valid_yamls_with_single_crd/dynatrace.package.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_with_single_crd/dynatrace.package.yaml
@@ -1,0 +1,4 @@
+packageName: oneagent
+channels:
+- name: alpha
+  currentCSV: dynatrace-monitoring.v0.2.0

--- a/features/steps/yamls_for_bundle/valid_yamls_without_crds/svcat.package.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_without_crds/svcat.package.yaml
@@ -1,0 +1,5 @@
+#! package-manifest: deploy/chart/catalog_resources/rh-operators/svcat.v0.1.34.clusterserviceversion.yaml
+packageName: svcat
+channels:
+  - name: alpha
+    currentCSV: svcat.v0.1.34

--- a/features/steps/yamls_for_bundle/valid_yamls_without_crds/svcat.v0.1.34.clusterserviceversion.yaml
+++ b/features/steps/yamls_for_bundle/valid_yamls_without_crds/svcat.v0.1.34.clusterserviceversion.yaml
@@ -1,0 +1,385 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: svcat.v0.1.34
+  namespace: placeholder
+  annotations:
+    categories: "openshift optional, service catalog, osb, osbapi, broker, svcat"
+    certified: "false"
+    description: Service Catalog lets you provision cloud services directly from the comfort of native Kubernetes tooling. This project is in incubation to bring integration with service brokers to the Kubernetes ecosystem via the Open Service Broker API.
+    containerImage: quay.io/openshift/origin-service-catalog
+    createdAt: 2018-12-01T00:00:00Z
+    support: AOS Service Catalog
+spec:
+  displayName: Service Catalog
+  description: Service Catalog lets you provision cloud services directly from the comfort of native Kubernetes tooling. This project is in incubation to bring integration with service brokers to the Kubernetes ecosystem via the Open Service Broker API.
+  version: 0.1.34
+  keywords: ['catalog', 'service', 'svcat', 'osb', 'broker']
+  maintainers:
+    - name: Red Hat
+      email: openshift-operators@redhat.com
+  provider:
+    name: Red Hat
+  links:
+    - name: Documentation
+      url: https://svc-cat.io/docs
+    - name: Service Catalog
+      url: https://github.com/openshift/service-catalog
+
+  installModes:
+    - type: OwnNamespace
+      supported: true
+    - type: SingleNamespace
+      supported: true
+    - type: MultiNamespace
+      supported: false
+    - type: AllNamespaces
+      supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+        - serviceAccountName: service-catalog-controller
+          rules:
+            - apiGroups:     [""]
+              resources:     ["configmaps"]
+              resourceNames: ["cluster-info"]
+              verbs:         ["get","create","list","watch","update"]
+            - apiGroups:     [""]
+              resources:     ["configmaps"]
+              verbs:         ["create", "list", "watch", "get", "update"]
+            - apiGroups:     [""]
+              resources:     ["configmaps"]
+              resourceNames: ["service-catalog-controller-manager"]
+              verbs:         ["get","update"]
+      clusterPermissions:
+        - serviceAccountName: service-catalog-controller
+          rules:
+            - apiGroups: [""]
+              resources: ["events"]
+              verbs:     ["create","patch","update"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs:     ["get","create","update","delete","list","watch","patch"]
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs:     ["get","list","update", "patch", "watch", "delete", "initialize"]
+            - apiGroups: [""]
+              resources: ["namespaces"]
+              verbs:     ["get","list","watch"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["clusterserviceclasses"]
+              verbs:     ["get","list","watch","create","patch","update","delete"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["clusterserviceplans"]
+              verbs:     ["get","list","watch","create","patch","update","delete"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["clusterservicebrokers"]
+              verbs:     ["get","list","watch"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["serviceinstances","servicebindings"]
+              verbs:     ["get","list","watch", "update"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["clusterservicebrokers/status","clusterserviceclasses/status","clusterserviceplans/status","serviceinstances/status","serviceinstances/reference","servicebindings/status","servicebindings/finalizers"]
+              verbs:     ["update"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["serviceclasses"]
+              verbs:     ["get","list","watch","create","patch","update","delete"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["serviceplans"]
+              verbs:     ["get","list","watch","create","patch","update","delete"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["servicebrokers"]
+              verbs:     ["get","list","watch"]
+            - apiGroups: ["servicecatalog.k8s.io"]
+              resources: ["servicebrokers/status","serviceclasses/status","serviceplans/status"]
+              verbs:     ["update"]
+        - serviceAccountName: service-catalog-apiserver
+          rules:
+            - apiGroups:     [""]
+              resources:     ["configmaps"]
+              resourceNames: ["extension-apiserver-authentication"]
+              verbs:         ["get"]
+            - apiGroups: [""]
+              resources: ["namespaces"]
+              verbs:     ["get", "list", "watch"]
+            - apiGroups: ["admissionregistration.k8s.io"]
+              resources: ["validatingwebhookconfigurations"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["admissionregistration.k8s.io"]
+              resources: ["mutatingwebhookconfigurations"]
+              verbs: ["get", "list", "watch"]
+            - apiGroups: ["authentication.k8s.io"]
+              resources: ["tokenreviews"]
+              verbs: ["create"]
+            - apiGroups: ["authorization.k8s.io"]
+              resources: ["subjectaccessreviews"]
+              verbs: ["create"]
+      deployments:
+        - name: svcat-apiserver
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+            selector:
+              matchLabels:
+                app: svcat-apiserver
+            template:
+              metadata:
+                labels:
+                  app: svcat-apiserver
+              spec:
+                serviceAccountName: service-catalog-apiserver
+                containers:
+                  - name: svcat-apiserver
+                    image: quay.io/openshift/origin-service-catalog:v4.0.0
+                    imagePullPolicy: IfNotPresent
+                    command: ["/usr/bin/service-catalog"]
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 140Mi
+                      requests:
+                        cpu: 100m
+                        memory: 40Mi
+                    args:
+                      - apiserver
+                      - --enable-admission-plugins
+                      - "NamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck"
+                      - --secure-port
+                      - "5443"
+                      - --etcd-servers
+                      - http://localhost:2379
+                      - -v
+                      - "3"
+                      - --feature-gates
+                      - OriginatingIdentity=true
+                      - --feature-gates
+                      - NamespacedServiceBroker=true
+                    ports:
+                      - containerPort: 5443
+                    volumeMounts:
+                      - name: apiservice-cert
+                        mountPath: /var/run/kubernetes-service-catalog
+                    readinessProbe:
+                      httpGet:
+                        port: 5443
+                        path: /healthz
+                        scheme: HTTPS
+                      failureThreshold: 1
+                      initialDelaySeconds: 30
+                      periodSeconds: 5
+                      successThreshold: 1
+                      timeoutSeconds: 5
+                    livenessProbe:
+                      httpGet:
+                        port: 5443
+                        path: /healthz
+                        scheme: HTTPS
+                      failureThreshold: 3
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      successThreshold: 1
+                      timeoutSeconds: 5
+                  - name: etcd
+                    image: quay.io/coreos/etcd:latest
+                    imagePullPolicy: Always
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 150Mi
+                      requests:
+                        cpu: 100m
+                        memory: 50Mi
+                    env:
+                      - name: ETCD_DATA_DIR
+                        value: /etcd-data-dir
+                    command:
+                      - /usr/local/bin/etcd
+                      - --listen-client-urls
+                      - http://0.0.0.0:2379
+                      - --advertise-client-urls
+                      - http://localhost:2379
+                    ports:
+                      - containerPort: 2379
+                    volumeMounts:
+                      - name: etcd-data-dir
+                        mountPath: /etcd-data-dir
+                    readinessProbe:
+                      httpGet:
+                        port: 2379
+                        path: /health
+                      failureThreshold: 1
+                      initialDelaySeconds: 30
+                      periodSeconds: 5
+                      successThreshold: 1
+                      timeoutSeconds: 5
+                    livenessProbe:
+                      httpGet:
+                        port: 2379
+                        path: /health
+                      failureThreshold: 3
+                      initialDelaySeconds: 30
+                      periodSeconds: 10
+                      successThreshold: 1
+                      timeoutSeconds: 5
+                volumes:
+                  - name: etcd-data-dir
+                    emptyDir: {}
+        - name: svcat-controller-manager
+          spec:
+            replicas: 1
+            strategy:
+              type: RollingUpdate
+            selector:
+              matchLabels:
+                app: svcat-controller-manager
+            template:
+              metadata:
+                labels:
+                  app: svcat-controller-manager
+              spec:
+                serviceAccountName: service-catalog-controller
+                containers:
+                  - name: svcat-controller-manager
+                    image: quay.io/openshift/origin-service-catalog:v4.0.0
+                    imagePullPolicy: IfNotPresent
+                    command: ["/usr/bin/service-catalog"]
+                    resources:
+                      limits:
+                        cpu: 100m
+                        memory: 150Mi
+                      requests:
+                        cpu: 100m
+                        memory: 100Mi
+                    env:
+                      - name: K8S_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                    args:
+                      - controller-manager
+                      - --secure-port
+                      - "8444"
+                      - -v
+                      - "3"
+                      - --leader-election-namespace
+                      - openshift-operators
+                      - --leader-elect-resource-lock
+                      - configmaps
+                      - --cluster-id-configmap-namespace=openshift-operators
+                      - --broker-relist-interval
+                      - "5m"
+                      - --feature-gates
+                      - "OriginatingIdentity=true"
+                      - --feature-gates
+                      - "AsyncBindingOperations=true"
+                      - --feature-gates
+                      - "NamespacedServiceBroker=true"
+                    ports:
+                      - containerPort: 8444
+                    readinessProbe:
+                      httpGet:
+                        port: 8444
+                        path: /healthz
+                        scheme: HTTPS
+                      failureThreshold: 1
+                      initialDelaySeconds: 20
+                      periodSeconds: 10
+                      successThreshold: 1
+                      timeoutSeconds: 2
+                    livenessProbe:
+                      httpGet:
+                        port: 8444
+                        path: /healthz
+                        scheme: HTTPS
+                      failureThreshold: 3
+                      initialDelaySeconds: 20
+                      periodSeconds: 10
+                      successThreshold: 1
+                      timeoutSeconds: 2
+                    # The following apiservice-cert is borrowed from the apiservice - it should be
+                    # replaced with one specific for the controller manager.  How to create service
+                    # for controller manager??
+                    volumeMounts:
+                      - name: apiservice-cert
+                        mountPath: /var/run/kubernetes-service-catalog
+                volumes:
+                  - name: apiservice-cert
+                    secret:
+                      defaultMode: 420
+                      items:
+                        - key: tls.crt
+                          path: apiserver.crt
+                        - key: tls.key
+                          path: apiserver.key
+                      secretName: v1beta1.servicecatalog.k8s.io-cert
+  apiservicedefinitions:
+    owned:
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ClusterServiceClass
+        name: clusterserviceclasses
+        displayName: ClusterServiceClass
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ClusterServicePlan
+        name: clusterserviceplans
+        displayName: ClusterServicePlan
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ClusterServiceBroker
+        name: clusterservicebrokers
+        displayName: ClusterServiceBroker
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ServiceInstance
+        name: serviceinstances
+        displayName: ServiceInstance
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ServiceBinding
+        name: servicebindings
+        displayName: ServiceBinding
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ServiceClass
+        name: serviceclasses
+        displayName: ServiceClass
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ServicePlan
+        name: serviceplans
+        displayName: ServicePlan
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443
+      - group: servicecatalog.k8s.io
+        version: v1beta1
+        kind: ServiceBroker
+        name: servicebrokers
+        displayName: ServiceBroker
+        description: A service catalog resource
+        deploymentName: svcat-apiserver
+        containerPort: 5443

--- a/features/verify.feature
+++ b/features/verify.feature
@@ -1,0 +1,20 @@
+@cli @verify
+Feature: Operator Courier command line verify operation
+
+  @valid
+  Scenario Outline: Operator Courier should be able to verify the valid input yaml files
+    * operator-courier should be able to verify the VALID input yaml files in the input directory "<source_dir>"
+
+    Examples:
+      |source_dir|
+      |features/steps/yamls_for_bundle/valid_yamls_without_crds|
+      |features/steps/yamls_for_bundle/valid_yamls_with_single_crd|
+      |features/steps/yamls_for_bundle/valid_yamls_with_multiple_crds|
+
+  @invalid
+  Scenario Outline: Operator Courier should be able to verify the valid input yaml files
+    * operator-courier should verify that the input yaml files in the input directory "<source_dir>" is invalid, return a non-zero status, and log error messages that contain "<error_message>"
+
+    Examples:
+      |source_dir                                                    |error_message|
+      |features/steps/yamls_for_bundle/invalid_yamls_without_package |ERROR:operatorcourier.validate:Bundle does not contain any packages.|

--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ tests_require = [
   'pytest',
   'pytest-cov',
   'testfixtures',
+  'behave',
 ]
 
 setup(

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py36,py37,flake8
 deps = .[test]
 commands =
     pytest --cov=operatorcourier {posargs}
+    behave --format=progress {posargs:features}
 
 [coverage:report]
 fail_under = 64


### PR DESCRIPTION
The integration tests currently only test the `verify` command. For the `push` command, we need to set up quay access token as environment variable. Due to some [restrictions](https://docs.travis-ci.com/user/environment-variables/#defining-variables-in-repository-settings) from Travis CI,

> Encrypted environment variables are not available to pull requests from forks due to the security risk of exposing such information to unknown code.

> Similarly, we do not provide these values to untrusted builds, triggered by pull requests from another repository.

We decided to include it later and run those tests directly on master, and trigger Travis CI builds periodically with cron jobs. Details are yet to be decided.