### PR TITLE
Add a class that would allow access to results from verification.

### DIFF
--- a/operatorcourier/bundle.py
+++ b/operatorcourier/bundle.py
@@ -1,0 +1,136 @@
+import copy
+import itertools
+import json
+import logging
+import yaml
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from operatorcourier.build import BuildCmd
+from operatorcourier.validate import ValidateCmd
+from operatorcourier.push import PushCmd
+from operatorcourier.format import format_bundle
+from operatorcourier.errors import OpCourierBadBundle
+
+logger = logging.getLogger(__name__)
+
+
+class OperatorBundle:
+    """Represents operator bundles, provides validation and push methods.
+
+    Build a new bundle using one of the following methods:
+        OperatorBundle.from_yaml_data()
+        OperatorBundle.from_directory()
+
+    The build methods accept validation parameters and will run validation
+    immediately after building. If you need to re-run validation with different
+    parameters, you can use the validate() method.
+    """
+
+    def __init__(self):
+        self._data = {}
+        self._valid = False
+        self._validation_info = None
+
+    def data_copy(self):
+        """Copy the bundle data (the original data must not be modified).
+
+        :return: A copy of the data in this bundle.
+        """
+        return copy.deepcopy(self._data)
+
+    @property
+    def valid(self):
+        return self._valid
+
+    @property
+    def validation_info(self):
+        return self._validation_info
+
+    @classmethod
+    def from_yaml_data(cls, yaml_data, **validation_args):
+        """Build an operator bundle from a list of yaml strings and validate it.
+
+        :param yaml_data: List of yaml strings to build this bundle from.
+        :param validation_args: Arguments for validation. See the validate()
+                                method for an accurate signature.
+
+        :raises OpCourierBadYaml: When an invalid yaml file is encountered.
+        :raises OpCourierBadArtifact: When a file is not any of {CSV, CRD, Package}.
+
+        :return: A validated operator bundle.
+        """
+        bundle = cls()
+        data = BuildCmd().build_bundle(yaml_data)
+        bundle._data = data
+
+        bundle.validate(**validation_args)
+        return bundle
+
+    @classmethod
+    def from_directory(cls, directory, **validation_args):
+        """Build an operator bundle from all y(a?)ml files in a directory
+        (top level only, no recursion) and validate it.
+
+        :param directory: Path to directory with yaml files for this bundle.
+        :param validation_args: Arguments for validation. See the validate()
+                                method for an accurate signature.
+
+        :raises OpCourierBadYaml: When an invalid yaml file is encountered.
+        :raises OpCourierBadArtifact: When a file is not any of {CSV, CRD, Package}.
+
+        :return: A validated operator bundle.
+        """
+        d = Path(directory)
+        yaml_files = itertools.chain(d.glob('*.yml'), d.glob('*.yaml'))
+        yaml_strings = (f.read_text() for f in yaml_files)
+
+        return cls.from_yaml_data(yaml_strings, **validation_args)
+
+    def validate(self, repository=None, ui_validate_io=False):
+        """Validate the bundle and save the info collected during validation.
+
+        :param repository: Optionally, check that the package name in the bundle
+                           matches the specified repository name.
+        :param ui_validate_io: Run additional operatorhub.io UI validation?
+        """
+        valid, info = ValidateCmd(ui_validate_io).validate(self._data, repository)
+        self._valid = valid
+        self._validation_info = info
+
+    def push(self, namespace, repository, release, auth_token):
+        """Format the bundle and push it to Quay.io.
+
+        :param namespace: Namespace that contains the repository for the application.
+        :param repository: Repository name of the application described by the bundle.
+        :param release: Release version of the bundle.
+        :param auth_token: Authentication token used to push to Quay.io.
+
+        :raises OpCourierBadBundle: When attempting to push an invalid bundle.
+        :raises OpCourierQuayError: When an error occurs while pushing to Quay.
+        """
+        if not self.valid:
+            logger.error("Bundle failed validation.")
+            raise OpCourierBadBundle(
+                'Resulting bundle is invalid, input yaml is improperly defined.',
+                validation_info=self.validation_info
+            )
+
+        with TemporaryDirectory() as tmp_dir:
+            bundle = format_bundle(self._data)
+            bundle_path = Path(tmp_dir) / 'bundle.yaml'
+
+            with bundle_path.open('w') as outfile:
+                yaml.dump(bundle, outfile, default_flow_style=False)
+                outfile.flush()
+
+            PushCmd().push(tmp_dir, namespace, repository, release, auth_token)
+
+    def write_validation_info(self, out_file):
+        """Write the info collected during validation to a file (as json).
+
+        :param out_file: The file which the validation info will be written to.
+        """
+        with open(out_file, 'w') as f:
+            json.dump(self.validation_info, f)
+            f.write('\n')

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -64,3 +64,20 @@ def test_make_bundle_invalid(yaml_files):
     }
     assert str(e) == e_msg
     assert e.validation_info == e_dict
+
+
+def test_build_bundle_invalid_usage():
+    with pytest.raises(TypeError):
+        api.build_bundle('defined', ['also defined'])
+
+
+def test_build_empty_bundle():
+    bundle = api.build_bundle(None, None)
+    expected_data = {
+        'data': {
+            'customResourceDefinitions': [],
+            'clusterServiceVersions': [],
+            'packages': []
+        }
+    }
+    assert bundle.data_copy() == expected_data

--- a/tests/test_bundle.py
+++ b/tests/test_bundle.py
@@ -1,0 +1,135 @@
+import pytest
+import yaml
+from pathlib import Path
+from testfixtures import LogCapture
+
+from operatorcourier.bundle import OperatorBundle
+from operatorcourier.format import unformat_bundle
+from operatorcourier.errors import OpCourierBadBundle
+
+
+@pytest.fixture
+def valid_bundle_dir():
+    return 'tests/test_files/bundles/api/bundle1'
+
+
+@pytest.fixture
+def valid_bundle_result(valid_bundle_dir):
+    path = Path(valid_bundle_dir) / 'results/bundle.yaml'
+    with path.open() as f:
+        return unformat_bundle(yaml.safe_load(f))
+
+
+@pytest.fixture
+def valid_bundle_yamls(valid_bundle_dir):
+    d = Path(valid_bundle_dir)
+    yaml_files = [d / 'crd.yml', d / 'csv.yaml', d / 'packages.yaml']
+    return [f.read_text() for f in yaml_files]
+
+
+@pytest.fixture
+def valid_bundle_validation_info(valid_bundle_dir):
+    path = Path(valid_bundle_dir) / 'results/validation.json'
+    with path.open() as f:
+        return yaml.safe_load(f)
+
+
+@pytest.fixture
+def invalid_bundle_yamls(valid_bundle_dir):
+    d = Path(valid_bundle_dir)
+    yaml_files = [d / 'crd.yml', d / 'csv.yaml']
+    return [f.read_text() for f in yaml_files]
+
+
+# -- Fixtures above, tests below ----------------------------------------------
+
+
+def test_bundle_is_invalid_by_default():
+    bundle = OperatorBundle()
+    assert not bundle.valid
+    assert bundle.validation_info is None
+
+
+def test_build_bundle_from_dir(valid_bundle_dir, valid_bundle_result):
+    bundle = OperatorBundle.from_directory(valid_bundle_dir)
+    assert bundle.data_copy() == valid_bundle_result
+
+
+def test_build_bundle_from_yamls(valid_bundle_yamls, valid_bundle_result):
+    bundle = OperatorBundle.from_yaml_data(valid_bundle_yamls)
+    assert bundle.data_copy() == valid_bundle_result
+
+
+def test_build_valid_bundle(valid_bundle_dir, valid_bundle_validation_info):
+    bundle = OperatorBundle.from_directory(valid_bundle_dir)
+    assert bundle.valid
+    assert bundle.validation_info == valid_bundle_validation_info
+
+
+def test_build_invalid_bundle(invalid_bundle_yamls):
+    bundle = OperatorBundle.from_yaml_data(invalid_bundle_yamls)
+    assert not bundle.valid
+    assert ('Bundle does not contain any packages.'
+            in bundle.validation_info['errors'])
+
+
+def test_validate_valid_bundle(valid_bundle_dir, valid_bundle_validation_info):
+    bundle = OperatorBundle.from_directory(valid_bundle_dir)
+    bundle._valid = False
+    bundle._validation_info = None
+
+    bundle.validate()
+
+    assert bundle.valid
+    assert bundle.validation_info == valid_bundle_validation_info
+
+
+def test_validate_invalid_bundle(invalid_bundle_yamls):
+    bundle = OperatorBundle.from_yaml_data(invalid_bundle_yamls)
+    bundle._valid = True
+    bundle._validation_info = None
+
+    bundle.validate()
+
+    assert not bundle.valid
+    assert ('Bundle does not contain any packages.'
+            in bundle.validation_info['errors'])
+
+
+def test_cannot_modify_bundle_data(valid_bundle_dir, valid_bundle_result):
+    bundle = OperatorBundle.from_directory(valid_bundle_dir)
+    data = bundle.data_copy()
+
+    data['data']['clusterServiceVersions'][0] = None
+    assert bundle._data == valid_bundle_result
+
+    data.clear()
+    assert bundle._data == valid_bundle_result
+
+
+def test_cannot_push_invalid_bundle(invalid_bundle_yamls):
+    bundle = OperatorBundle.from_yaml_data(invalid_bundle_yamls)
+
+    with pytest.raises(OpCourierBadBundle) as exc_info, LogCapture() as logs:
+        bundle.push('a', 'b', 'c', 'd')
+
+    msg = str(exc_info.value)
+    assert msg == 'Resulting bundle is invalid, input yaml is improperly defined.'
+    logs.check_present(('operatorcourier.bundle',
+                        'ERROR',
+                        'Bundle failed validation.'))
+
+
+def test_write_validation_info(valid_bundle_dir, valid_bundle_validation_info):
+    bundle = OperatorBundle.from_directory(valid_bundle_dir)
+    bundle.validate()
+
+    out_file = Path(valid_bundle_dir) / 'results/tmp.json'
+    bundle.write_validation_info(out_file)
+
+    with out_file.open() as f:
+        output = yaml.safe_load(f)
+
+    out_file.unlink()
+
+    assert output == valid_bundle_validation_info

--- a/tests/test_files/bundles/api/bundle1/results/validation.json
+++ b/tests/test_files/bundles/api/bundle1/results/validation.json
@@ -1,0 +1,1 @@
+{"warnings": ["csv metadata.annotations not defined.", "csv spec.icon not defined"], "errors": []}


### PR DESCRIPTION
[OMPS](https://github.com/release-engineering/operators-manifests-push-service) would like access to results from bundle verification.

The idea is that you would use the new `build_bundle()` api function to get an `OperatorBundle` object. This object would allow you to `validate()` and `push()` and would store the info from validation.

The existing api functions were rewritten to demonstrate.