### PR TITLE
Update tox for integration tests and add tests for push

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -58,6 +58,14 @@ certain level. This is intended to ensure that all code changes submitted to
 this project are appropriately unit tested. For the current value, see the
 `[coverage:report]` section in `tox.ini`.
 
+In order to run integration tests for the `push` command, you will need to set 
+`QUAY_NAMESPACE` and `QUAY_ACCESS_TOKEN` environment variables locally, or add 
+them to tox.ini, for example
+
+    setenv =
+        QUAY_NAMESPACE = my_quay_namespace
+        QUAY_ACCESS_TOKEN = basic aBcDeFaBcDeFaBcDeFaBcDeFaBcDeF==
+
 
 ## Release, Deploy, and Clean the Project
 

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+echo "Running integration tests triggered by $TRAVIS_EVENT_TYPE..."
+
+pytest tests/integration/test_verify.py
+
+# only runs if the Travis build is triggered by a cronjob, or
+# $QUAY_NAMESPACE and $QUAY_ACCESS_TOKEN is set locally
+if [[ $TRAVIS_EVENT_TYPE == 'cron' ]] || (! [[ -z $QUAY_NAMESPACE ]] && ! [[ -z $QUAY_ACCESS_TOKEN ]]); then
+  pytest tests/integration/test_push.py
+fi

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -1,0 +1,74 @@
+import pytest
+import subprocess
+from os import getenv
+from random import randint
+
+import requests
+
+quay_namespace = getenv('QUAY_NAMESPACE')
+quay_access_token = getenv('QUAY_ACCESS_TOKEN')
+
+
+@pytest.mark.parametrize('source_dir,repository_name', [
+    ('tests/test_files/yaml_source_dir/valid_yamls_with_multiple_crds',
+     'marketplace'),
+    ('tests/test_files/yaml_source_dir/valid_yamls_with_single_crd',
+     'oneagent'),
+    ('tests/test_files/yaml_source_dir/valid_yamls_without_crds',
+     'svcat'),
+])
+def test_push_valid_sources(source_dir, repository_name):
+    release_version = f"{randint(0,99999)}.{randint(0,99999)}.{randint(0,99999)}"
+
+    cmd = f'operator-courier push {source_dir} {quay_namespace} ' \
+          f"{repository_name} {release_version} '{quay_access_token}'"
+    process = subprocess.Popen(cmd,
+                               shell=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
+    exit_code = process.wait()
+    assert exit_code == 0
+    ensure_application_release_removed(repository_name, release_version)
+
+
+def ensure_application_release_removed(repository_name, release_version):
+    api = f'https://quay.io/cnr/api/v1/packages/' \
+          f'{quay_namespace}/{repository_name}/{release_version}/helm'
+    headers = {
+        'Content-Type': 'application/json',
+        'Authorization': quay_access_token
+    }
+    res = requests.delete(api, headers=headers)
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize('source_dir,repository_name,release_version,error_message', [
+    ('tests/test_files/yaml_source_dir/invalid_yamls_without_package',
+     'oneagent',
+     '0.0.1',
+     'ERROR:operatorcourier.validate:Bundle does not contain any packages.'),
+    ('tests/test_files/yaml_source_dir/invalid_yamls_multiple_packages',
+     'oneagent',
+     '0.0.1',
+     'ERROR:operatorcourier.validate:'
+     'Only 1 package is expected to exist per bundle, but got 2.'),
+    ('tests/test_files/yaml_source_dir/valid_yamls_with_single_crd',
+     'wrong-repo-name',
+     '0.0.1',
+     'ERROR:operatorcourier.validate:'
+     'The packageName (oneagent) in bundle does not match '
+     'repository name (wrong-repo-name) provided as command line argument.'),
+])
+def test_push_invalid_sources(source_dir, repository_name,
+                              release_version, error_message):
+    cmd = f'operator-courier push {source_dir} {quay_namespace} ' \
+          f"{repository_name} {release_version} '{quay_access_token}'"
+    process = subprocess.Popen(cmd,
+                               shell=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT)
+    exit_code = process.wait()
+    assert exit_code != 0
+
+    outputs = process.stdout.read().decode('utf-8')
+    assert error_message in outputs

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,13 @@ envlist = py36,py37,flake8
 [testenv]
 deps = .[test]
 commands =
-    pytest --cov=operatorcourier {posargs}
+    pytest --ignore=tests/integration --cov=operatorcourier {posargs}
+    ./run_integration_tests.sh
+
+passenv =
+    TRAVIS_*
+    QUAY_NAMESPACE
+    QUAY_ACCESS_TOKEN
 
 [coverage:report]
 fail_under = 64


### PR DESCRIPTION
- Update tox config to run integration tests
- Add a script that runs the set of integration tests based on Travis build triggering event
- Add integration tests for `push` command