### PR TITLE
flatten: copy files to dest_dir when structure is already flat

### DIFF
--- a/operatorcourier/flatten.py
+++ b/operatorcourier/flatten.py
@@ -27,10 +27,14 @@ def get_flattened_files_info(source_dir: str) -> [(str, str)]:
     """
 
     # extract package file and version folders from source_dir
-    _, folder_names, file_names = next(os.walk(source_dir))
+    root, folder_names, file_names = next(os.walk(source_dir))
     if not folder_names:
         logger.info('The source directory is already flat.')
-        return []
+        # just return files from dir as they are already flat
+        return [
+            (os.path.join(root, name), name)
+            for name in file_names
+        ]
 
     file_paths_to_copy = []  # [ (SRC_FILE_PATH, NEW_FILE_NAME) ]
 

--- a/tests/test_flatten.py
+++ b/tests/test_flatten.py
@@ -89,8 +89,20 @@ import operatorcourier.flatten as flatten
         ('tests/test_files/bundles/flatten/etcd_valid_input_4/0.9.2/etcdcluster.crd.yaml',
          'etcdcluster.crd.yaml'),
     ]),
-    # if the source_dir is already flat, we return an empty list to indicate that
-    ('tests/test_files/bundles/flatten/etcd_valid_input_5', []),
+    # if the source_dir is already flat, just return files
+    ('tests/test_files/bundles/flatten/etcd_valid_input_5', [
+        ('tests/test_files/bundles/flatten/etcd_valid_input_5/etcdbackup.crd.yaml',
+         'etcdbackup.crd.yaml'),
+        ('tests/test_files/bundles/flatten/etcd_valid_input_5/etcdcluster.crd.yaml',
+         'etcdcluster.crd.yaml'),
+        ('tests/test_files/bundles/flatten/etcd_valid_input_5/etcdrestore.crd.yaml',
+         'etcdrestore.crd.yaml'),
+        (('tests/test_files/bundles/flatten/etcd_valid_input_5/etcdoperator.'
+          'clusterserviceversion.yaml'),
+         'etcdoperator.clusterserviceversion.yaml'),
+        ('tests/test_files/bundles/flatten/etcd_valid_input_5/etcd.package.yaml',
+         'etcd.package.yaml'),
+    ]),
 ])
 def test_flatten_with_valid_bundle(input_dir, expected_flattened_file_paths):
     actual_flattened_file_paths = flatten.get_flattened_files_info(input_dir)


### PR DESCRIPTION
operator-courier flatten should copy source_dir to dest_dir when
structure is already flat.

It should support this worklow:
```
$ operator-courier flatten source_dir dest_dir && zip archive.zip
dest_dir/*
```

Currently it fails when dest_dir doesn't exist or constructs empty
archive.

Signed-off-by: Martin Bašti <mbasti@redhat.com>