### PR TITLE
CliParser: Print help when no argument is passed

### DIFF
--- a/operatorcourier/cli.py
+++ b/operatorcourier/cli.py
@@ -135,7 +135,12 @@ class _CliParser():
             level=logging.DEBUG if args.verbose else logging.WARNING
         )
 
-        args.func(args)
+        func = getattr(args, 'func', None)
+        if callable(func):
+            func(args)
+        else:
+            parser.print_help(sys.stderr)
+            sys.exit(2)
 
     def verify(self, args):
         """Run the verify command


### PR DESCRIPTION
This fixes the issue in the CliParser that shows error when no argument
is passed by printing the help message and exiting.

```
$ operator-courier 
'Namespace' object has no attribute 'func'
```