### PR TITLE
Provide doc links for error messages

### DIFF
--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -49,15 +49,38 @@ def test_ui_valid_bundle_io(bundle, expected_validation_results_dict):
 @pytest.mark.parametrize('bundle,expected_validation_results_dict', [
         ("tests/test_files/bundles/verification/ui.invalid.bundle.yaml",
             {'errors': [
-                "csv.spec.links must be a list of name & url pairs.",
+                "csv.spec.links must be a list of name & url pairs. "
+                "See links below for more details and examples:"
+                "\n\n"
+                "https://github.com/operator-framework/community-operators/"
+                "blob/master/docs/required-fields.md\n"
+                "https://github.com/operator-framework/operator-lifecycle-manager/"
+                "blob/master/Documentation/design/building-your-csv.md",
+
                 "spec.version invalid is not a valid semver "
                 "(example of a valid semver is: 1.0.12)",
+
                 "metadata.annotations.capabilities invalid "
-                "is not a valid capabilities level",
+                "is not a valid capabilities level. See links below "
+                "for more details and examples:"
+                "\n\n"
+                "https://github.com/operator-framework/community-operators/"
+                "blob/master/docs/required-fields.md#required-fields-for-operatorhubio",
+
                 "spec.icon[0].mediatype image/invalid is not "
-                "a valid mediatype. It must be one of \"image/gif\", "
-                "\"image/jpeg\", \"image/png\", \"image/svg+xml\"",
-                "category invalid is not a valid category",
+                'a valid mediatype. It must be one of "image/gif", '
+                '"image/jpeg", "image/png", "image/svg+xml". See links below '
+                "for more details and examples:"
+                "\n\n"
+                "https://github.com/operator-framework/community-operators/"
+                "blob/master/docs/required-fields.md#required-fields-for-operatorhubio",
+
+                "category invalid is not a valid category. See links below "
+                "for more details and examples:"
+                "\n\n"
+                "https://github.com/operator-framework/community-operators/blob/"
+                "master/docs/required-fields.md#categories",
+
                 "UI validation failed to verify that required fields "
                 "for operatorhub.io are properly formatted."
                 ],
@@ -138,13 +161,25 @@ def get_bundle(bundle):
 
     ('tests/test_files/bundles/verification/csvmissingkindfield.invalid.bundle.yaml',
      ('operatorcourier.validate', 'ERROR',
-      'kind not defined for item in spec.customresourcedefinitions.')),
+      'kind not defined for item in spec.customresourcedefinitions. See links below '
+      'for more details and examples:'
+      '\n\n'
+      'https://github.com/operator-framework/operator-lifecycle-manager/blob/master/'
+      'Documentation/design/building-your-csv.md#owned-crds')),
     ('tests/test_files/bundles/verification/csvmissingnamefield.invalid.bundle.yaml',
      ('operatorcourier.validate', 'ERROR',
-      'name not defined for item in spec.customresourcedefinitions.')),
+      'name not defined for item in spec.customresourcedefinitions. See links below '
+      'for more details and examples:'
+      '\n\n'
+      'https://github.com/operator-framework/operator-lifecycle-manager/blob/master/'
+      'Documentation/design/building-your-csv.md#owned-crds')),
     ('tests/test_files/bundles/verification/csvmissingversionfield.invalid.bundle.yaml',
      ('operatorcourier.validate', 'ERROR',
-      'version not defined for item in spec.customresourcedefinitions.')),
+      'version not defined for item in spec.customresourcedefinitions. See links below '
+      'for more details and examples:'
+      '\n\n'
+      'https://github.com/operator-framework/operator-lifecycle-manager/blob/master/'
+      'Documentation/design/building-your-csv.md#owned-crds')),
 ])
 def test_invalid_bundle_missing_fields(bundleFile, logInfo):
     _test_invalid_bundle_with_log(bundleFile, logInfo)


### PR DESCRIPTION
**Problem**:
Currently, whenever operator-courier encounters an error, it mentions if a field is missing/invalid but does not mention how to fix the error.

**Solution**:
Add related document links to error messages so that courier users can learn more about error and how to fix it.

---

Below is how I categorize the error messages, and add one or more help urls to the error message. Please comment if my categorization needs to be improved, or better links can be used for some error messages. Then I will update it in the code accordingly.


# No help URLs added
```python
_log_error("%s is not a valid email", maintainer["email"])
_log_error("%s is not a valid url", link["url"])
_log_error("Bundle does not contain any %s." % typeName)
_log_error("Bundle does not contain any %s." % typeName)
_log_error("Bundle does not contain base data field.")
_log_error("UI validation failed to verify required fields for operatorhub.io exist.")
_log_error("UI validation failed to verify that required fields for operatorhub.io are properly formatted.")
_log_error("`CRD.spec.names.plural`.`CRD.spec.group` does not match "
_log_error('CRD.spec.names.kind does not match CSV.spec.crd.owned.kind')
_log_error('CRD.spec.version does not match CSV.spec.crd.owned.version')
_log_error("channel.currentCSV %s is not included in list of csvs",
_log_error("metadata.annotations.certified is not of type string")
_log_error("no package channels defined.")
_log_error("package channel.currentCSV not defined.")
_log_error("package channel.name not defined.")
_log_error("package channels not defined.")
_log_error("packageName not defined.")
_log_error('Only 1 package is expected to exist per bundle, but got %d.', num_pkgs)
_log_error('The packageName (%s) in bundle does not match repository name (%s) provided as command line argument.'
_log_error("crd apiVersion not defined.")
_log_error("crd metadata not defined.")
_log_error("crd metadata.name not defined.")
_log_error("crd spec not defined.")
_log_error("crd spec.group not defined.")
_log_error("crd spec.names not defined.")
_log_error("crd spec.names.kind not defined.")
_log_error("crd spec.names.plural not defined.")
_log_error("crd spec.version not defined.")
```

# invalid_category
- https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#categories

```python
log_error("category %s is not a valid category")
```

# missing_owned_crd_field_in_csv

- https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#your-custom-resource-definitions

```python
_log_error("spec.customresourcedefinitions.owned not defined for csv")
_log_error("kind not defined for item in spec.customresourcedefinitions.")
_log_error("name not defined for item in spec.customresourcedefinitions.")
_log_error("version not defined for item in spec.customresourcedefinitions.")
_log_error("custom resource definition %s referenced in csv not defined in root list of crds", csvOwnedCrd["name"])
```


# invalid_alm_examples
- https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md#crd-templates

```python
_log_error("You should have alm-examples for every owned CRD")
_log_error("metadata.annotations.alm-examples contains invalid json string")
```




# missing_field_for_operatorhub_io
- https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md#required-fields-for-operatorhubio

```python
_log_error("csv metadata.%s not defined. %s", field["field"], field["description"])
_log_error("csv metadata.annotations.%s not defined. %s", field["field"], field["description"])
_log_error("spec.icon can only contain two fields: \"base64data\" and \"mediatype\"")
_log_error("spec.icon should be a list")
_log_error("spec.icon should be a singleton list")
_log_error("spec.icon[0] must contain the fields \"base64data\" and \"mediatype\".")
_log_error("spec.icon[0].mediatype %s is not a valid mediatype.")
_log_error("spec.version %s is not a valid semver (example of a valid semver is: 1.0.12)",
_log_error("metadata.annotations.capabilities %s is not a valid capabilities level", annotations["capabilities"])
```


# csv_field_issue
- https://github.com/operator-framework/community-operators/blob/master/docs/required-fields.md
- https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/building-your-csv.md

```python
_log_error("csv %s not defined.", field)
_log_error("csv apiVersion not defined.")
_log_error("csv metadata not defined.")
_log_error("csv metadata not defined.")
_log_error("csv metadata.name not defined.")
_log_error("csv metadata.name not defined.")
_log_error("csv spec not defined.")
_log_error("csv spec.%s not defined. %s", field["field"], field["description"])
_log_error("csv spec.install not defined")
_log_error("csv spec.installModes not defined")
_log_error("csv.spec.links element should contain both name and url")
_log_error("csv.spec.links must be a list of name & url pairs.")
_log_error("csv.spec.maintainers element should contain both name and email")
_log_error("csv.spec.maintainers must be a list of name & email pairs.")
_log_error("csv.spec.provider element should have a single field \"name\".")
_log_error("csv.spec.provider should be a singleton list.")
_log_error("csv.spec.provider should contain a \"name\" field.")
```
