### PR TITLE
Explicitly handle an error case.

### DIFF
--- a/operatorcourier/flatten.py
+++ b/operatorcourier/flatten.py
@@ -151,6 +151,11 @@ def get_package_path(base_dir: str, file_names_in_base_dir: list) -> str:
             logger.error(msg)
             raise errors.OpCourierBadBundle(msg, {})
 
+    if not packages:
+        msg = f'The input source directory expects at least 1 valid package file.'
+        logger.error(msg)
+        raise errors.OpCourierBadBundle(msg, {})
+
     return packages[0]
 
 


### PR DESCRIPTION
Without this, it is possible to get into a situation where `packages` is `[]`, and the `return packages[0]` line raises an `IndexError`.