### PR TITLE
validate: add validations for csv spec.install

### DIFF
--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -176,7 +176,10 @@ class ValidateCmd():
             self._log_error("csv spec.installModes not defined")
             valid = False
 
-        if "install" not in spec:
+        if "install" in spec:
+            if self._csv_spec_install_validation(spec["install"]) is False:
+                valid = False
+        else:
             self._log_error("csv spec.install not defined")
             valid = False
 
@@ -254,6 +257,59 @@ class ValidateCmd():
                                                         "match "
                                                         "CSV.spec.crd.owned.name")
                                         valid = False
+        return valid
+
+    def _csv_spec_install_validation(self, install):
+        valid = True
+
+        wantStrategyList = ["deployment"]
+
+        # strategy check (required)
+        if "strategy" in install:
+            if install["strategy"] not in wantStrategyList:
+                self._log_error(
+                    "csv spec.install.strategy must be one of %s" % wantStrategyList)
+                valid = False
+        else:
+            self._log_error("csv spec.install.strategy not defined")
+            valid = False
+
+        # spec check (required)
+        if "spec" in install:
+            # deployments check (required)
+            if "deployments" in install["spec"]:
+                deployments = install["spec"]["deployments"]
+                if not isinstance(deployments, (list,)):
+                    self._log_error(
+                        "csv spec.install.spec.deployments should be a list")
+                    valid = False
+            else:
+                self._log_error("csv spec.install.spec.deployments not defined")
+
+            # permissions check (optional)
+            try:
+                permissions = install["spec"]["permissions"]
+                if not isinstance(permissions, (list,)):
+                    self._log_error("csv spec.install.spec.permissions should be a list")
+                    valid = False
+            except KeyError:
+                pass
+
+            # clusterPermissions check (optional)
+            try:
+                clusterPermissions = install["spec"]["clusterPermissions"]
+                if not isinstance(clusterPermissions, (list,)):
+                    self._log_error(
+                        "csv spec.install.spec.clusterPermissions should be a list"
+                    )
+                    valid = False
+            except KeyError:
+                pass
+
+        else:
+            self._log_error("csv spec.install.spec not defined")
+            valid = False
+
         return valid
 
     def _csv_metadata_validation(self, metadata):

--- a/tests/test_files/bundles/verification/csvinstallspecnotlists.invalid.bundle.yaml
+++ b/tests/test_files/bundles/verification/csvinstallspecnotlists.invalid.bundle.yaml
@@ -1,0 +1,310 @@
+# CSV.spec.install.spec.{deployments,permissions,clusterPermissions} are not lists in this file
+data:
+  clusterServiceVersions: |
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+          categories: openshift required
+          certified: 'true'
+          containerImage: quay.io/openshift/origin-operator-marketplace:latest
+          createdAt: 2019/11/15
+          description: An operator to run the OpenShift marketplace
+          healthIndex: B
+          repository: https://github.com/operator-framework/operator-marketplace
+          support: Red Hat
+        name: marketplace-operator.v0.0.1
+        namespace: placeholder
+      spec:
+        customresourcedefinitions:
+          owned:
+          - description: Represents an OperatorSource.
+            displayName: Operator Source
+            kind: OperatorSource
+            name: operatorsources.marketplace.redhat.com
+            specDescriptors:
+            - description: The type of the operator source.
+              displayName: Type
+              path: type
+            - description: Points to the remote app registry server from where operator
+                manifests can be fetched.
+              displayName: Endpoint
+              path: endpoint
+            - description: 'The namespace in app registry.
+
+                Only operator manifests under this namespace will be visible.
+
+                Please note that this is not a k8s namespace.'
+              displayName: Registry Namespace
+              path: registryNamespace
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+          - description: Represents a CatalogSourceConfig object which is used to configure
+              a CatalogSource.
+            displayName: Catalog Source Config
+            kind: CatalogSourceConfig
+            name: catalogsourceconfigs.marketplace.redhat.com
+            specDescriptors:
+            - description: The namespace where the operators will be enabled.
+              displayName: Target Namespace
+              path: targetNamespace
+            - description: List of operator(s) which will be enabled in the target namespace
+              displayName: Packages
+              path: packages
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+        description: Marketplace is a gateway for users to consume off-cluster Operators
+          which will include Red Hat, ISV, optional OpenShift and community content.
+        displayName: marketplace-operator
+        install:
+          spec:
+            permissions:
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+            clusterPermissions:
+              rules:
+              - apiGroups:
+                - marketplace.redhat.com
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              - apiGroups:
+                - ''
+                resources:
+                - services
+                - configmaps
+                verbs:
+                - '*'
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - catalogsources
+                verbs:
+                - '*'
+              serviceAccountName: marketplace-operator
+            deployments:
+              name: marketplace-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: marketplace-operator
+                template:
+                  metadata:
+                    labels:
+                      name: marketplace-operator
+                    name: marketplace-operator
+                  spec:
+                    containers:
+                    - command:
+                      - marketplace-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: marketplace-operator
+                      image: quay.io/openshift/origin-operator-marketplace:latest
+                      imagePullPolicy: Always
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                      name: marketplace-operator
+                      ports:
+                      - containerPort: 60000
+                        name: metrics
+                      - containerPort: 8080
+                        name: healthz
+                      readinessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                    serviceAccountName: marketplace-operator
+          strategy: deployment
+        installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - marketplace
+        - catalog
+        - olm
+        - admin
+        labels:
+          name: marketplace-operator
+        links:
+        - name: Markplace Operator Source Code
+          url: https://github.com/operator-framework/operator-marketplace
+        maintainers:
+        - email: aos-marketplace@redhat.com
+          name: AOS Marketplace Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        selector:
+          matchLabels:
+            name: marketplace-operator
+        version: 0.0.1
+  customResourceDefinitions: |
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents a CatalogSourceConfig.
+          displayName: Catalog Source Config
+        name: catalogsourceconfigs.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.targetNamespace
+          description: The namespace where the operators will be enabled
+          name: TargetNamespace
+          type: string
+        - JSONPath: .spec.packages
+          description: List of operator(s) which will be enabled in the target namespace
+          name: Packages
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the CatalogSourceConfig
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: CatalogSourceConfig
+          listKind: CatalogSourceConfigList
+          plural: catalogsourceconfigs
+          shortNames:
+          - csc
+          singular: catalogsourceconfig
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for a CatalogSourceConfig
+                properties:
+                  packages:
+                    description: Comma separated list of operator(s) without spaces
+                      which will be enabled in the target namespace
+                    type: string
+                  targetNamespace:
+                    description: The namespace where the operators will be enabled
+                    type: string
+                required:
+                - targetNamespace
+                - packages
+                type: object
+        version: v1alpha1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents an OperatorSource.
+          displayName: Operator Source
+        name: operatorsources.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.type
+          description: The type of the OperatorSource
+          name: Type
+          type: string
+        - JSONPath: .spec.endpoint
+          description: The endpoint of the OperatorSource
+          name: Endpoint
+          type: string
+        - JSONPath: .spec.registryNamespace
+          description: App registry namespace
+          name: Registry
+          type: string
+        - JSONPath: .spec.displayName
+          description: Display (pretty) name to indicate the OperatorSource's name
+          name: DisplayName
+          type: string
+        - JSONPath: .spec.publisher
+          description: Publisher of the OperatorSource
+          name: Publisher
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the OperatorSource
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: OperatorSource
+          listKind: OperatorSourceList
+          plural: operatorsources
+          shortNames:
+          - opsrc
+          singular: operatorsource
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for an OperatorSource.
+                properties:
+                  endpoint:
+                    description: Points to the remote app registry server from where
+                      operator manifests can be fetched.
+                    type: string
+                  registryNamespace:
+                    description: 'The namespace in app registry.
+
+                      Only operator manifests under this namespace will be visible.
+
+                      Please note that this is not a k8s namespace.'
+                    type: string
+                  type:
+                    description: The type of the OperatorSource
+                    pattern: appregistry
+                    type: string
+                required:
+                - type
+                - endpoint
+                - registryNamespace
+                type: object
+        version: v1alpha1
+  packages: |
+    - channels:
+      - currentCSV: marketplace-operator.v0.0.1
+        name: alpha
+      packageName: marketplace

--- a/tests/test_files/bundles/verification/csvinstallstrategywrongvalue.invalid.bundle.yaml
+++ b/tests/test_files/bundles/verification/csvinstallstrategywrongvalue.invalid.bundle.yaml
@@ -1,0 +1,310 @@
+# CSV.spec.install.strategy has unexpected value in this file
+data:
+  clusterServiceVersions: |
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+          categories: openshift required
+          certified: 'true'
+          containerImage: quay.io/openshift/origin-operator-marketplace:latest
+          createdAt: 2019/11/15
+          description: An operator to run the OpenShift marketplace
+          healthIndex: B
+          repository: https://github.com/operator-framework/operator-marketplace
+          support: Red Hat
+        name: marketplace-operator.v0.0.1
+        namespace: placeholder
+      spec:
+        customresourcedefinitions:
+          owned:
+          - description: Represents an OperatorSource.
+            displayName: Operator Source
+            kind: OperatorSource
+            name: operatorsources.marketplace.redhat.com
+            specDescriptors:
+            - description: The type of the operator source.
+              displayName: Type
+              path: type
+            - description: Points to the remote app registry server from where operator
+                manifests can be fetched.
+              displayName: Endpoint
+              path: endpoint
+            - description: 'The namespace in app registry.
+
+                Only operator manifests under this namespace will be visible.
+
+                Please note that this is not a k8s namespace.'
+              displayName: Registry Namespace
+              path: registryNamespace
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+          - description: Represents a CatalogSourceConfig object which is used to configure
+              a CatalogSource.
+            displayName: Catalog Source Config
+            kind: CatalogSourceConfig
+            name: catalogsourceconfigs.marketplace.redhat.com
+            specDescriptors:
+            - description: The namespace where the operators will be enabled.
+              displayName: Target Namespace
+              path: targetNamespace
+            - description: List of operator(s) which will be enabled in the target namespace
+              displayName: Packages
+              path: packages
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+        description: Marketplace is a gateway for users to consume off-cluster Operators
+          which will include Red Hat, ISV, optional OpenShift and community content.
+        displayName: marketplace-operator
+        install:
+          spec:
+            permissions:
+            - rules:
+              - apiGroups:
+                - ""
+                resources:
+                - namespaces
+                verbs:
+                - get
+            clusterPermissions:
+            - rules:
+              - apiGroups:
+                - marketplace.redhat.com
+                resources:
+                - '*'
+                verbs:
+                - '*'
+              - apiGroups:
+                - ''
+                resources:
+                - services
+                - configmaps
+                verbs:
+                - '*'
+              - apiGroups:
+                - operators.coreos.com
+                resources:
+                - catalogsources
+                verbs:
+                - '*'
+              serviceAccountName: marketplace-operator
+            deployments:
+            - name: marketplace-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: marketplace-operator
+                template:
+                  metadata:
+                    labels:
+                      name: marketplace-operator
+                    name: marketplace-operator
+                  spec:
+                    containers:
+                    - command:
+                      - marketplace-operator
+                      env:
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+                      - name: OPERATOR_NAME
+                        value: marketplace-operator
+                      image: quay.io/openshift/origin-operator-marketplace:latest
+                      imagePullPolicy: Always
+                      livenessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                      name: marketplace-operator
+                      ports:
+                      - containerPort: 60000
+                        name: metrics
+                      - containerPort: 8080
+                        name: healthz
+                      readinessProbe:
+                        httpGet:
+                          path: /healthz
+                          port: 8080
+                    serviceAccountName: marketplace-operator
+          strategy: foodeployment
+        installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - marketplace
+        - catalog
+        - olm
+        - admin
+        labels:
+          name: marketplace-operator
+        links:
+        - name: Markplace Operator Source Code
+          url: https://github.com/operator-framework/operator-marketplace
+        maintainers:
+        - email: aos-marketplace@redhat.com
+          name: AOS Marketplace Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        selector:
+          matchLabels:
+            name: marketplace-operator
+        version: 0.0.1
+  customResourceDefinitions: |
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents a CatalogSourceConfig.
+          displayName: Catalog Source Config
+        name: catalogsourceconfigs.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.targetNamespace
+          description: The namespace where the operators will be enabled
+          name: TargetNamespace
+          type: string
+        - JSONPath: .spec.packages
+          description: List of operator(s) which will be enabled in the target namespace
+          name: Packages
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the CatalogSourceConfig
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: CatalogSourceConfig
+          listKind: CatalogSourceConfigList
+          plural: catalogsourceconfigs
+          shortNames:
+          - csc
+          singular: catalogsourceconfig
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for a CatalogSourceConfig
+                properties:
+                  packages:
+                    description: Comma separated list of operator(s) without spaces
+                      which will be enabled in the target namespace
+                    type: string
+                  targetNamespace:
+                    description: The namespace where the operators will be enabled
+                    type: string
+                required:
+                - targetNamespace
+                - packages
+                type: object
+        version: v1alpha1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents an OperatorSource.
+          displayName: Operator Source
+        name: operatorsources.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.type
+          description: The type of the OperatorSource
+          name: Type
+          type: string
+        - JSONPath: .spec.endpoint
+          description: The endpoint of the OperatorSource
+          name: Endpoint
+          type: string
+        - JSONPath: .spec.registryNamespace
+          description: App registry namespace
+          name: Registry
+          type: string
+        - JSONPath: .spec.displayName
+          description: Display (pretty) name to indicate the OperatorSource's name
+          name: DisplayName
+          type: string
+        - JSONPath: .spec.publisher
+          description: Publisher of the OperatorSource
+          name: Publisher
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the OperatorSource
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: OperatorSource
+          listKind: OperatorSourceList
+          plural: operatorsources
+          shortNames:
+          - opsrc
+          singular: operatorsource
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for an OperatorSource.
+                properties:
+                  endpoint:
+                    description: Points to the remote app registry server from where
+                      operator manifests can be fetched.
+                    type: string
+                  registryNamespace:
+                    description: 'The namespace in app registry.
+
+                      Only operator manifests under this namespace will be visible.
+
+                      Please note that this is not a k8s namespace.'
+                    type: string
+                  type:
+                    description: The type of the OperatorSource
+                    pattern: appregistry
+                    type: string
+                required:
+                - type
+                - endpoint
+                - registryNamespace
+                type: object
+        version: v1alpha1
+  packages: |
+    - channels:
+      - currentCSV: marketplace-operator.v0.0.1
+        name: alpha
+      packageName: marketplace

--- a/tests/test_files/bundles/verification/csvmissinginstallattributes.invalid.bundle.yaml
+++ b/tests/test_files/bundles/verification/csvmissinginstallattributes.invalid.bundle.yaml
@@ -1,0 +1,239 @@
+# CSV.spec.install.{strategy,spec} are missing in this file
+data:
+  clusterServiceVersions: |
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        annotations:
+          alm-examples: '[{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdCluster","metadata":{"name":"example","namespace":"default"},"spec":{"size":3,"version":"3.2.13"}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdRestore","metadata":{"name":"example-etcd-cluster"},"spec":{"etcdCluster":{"name":"example-etcd-cluster"},"backupStorageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}},{"apiVersion":"etcd.database.coreos.com/v1beta2","kind":"EtcdBackup","metadata":{"name":"example-etcd-cluster-backup"},"spec":{"etcdEndpoints":["<etcd-cluster-endpoints>"],"storageType":"S3","s3":{"path":"<full-s3-path>","awsSecret":"<aws-secret>"}}}]'
+          categories: openshift required
+          certified: 'true'
+          containerImage: quay.io/openshift/origin-operator-marketplace:latest
+          createdAt: 2019/11/15
+          description: An operator to run the OpenShift marketplace
+          healthIndex: B
+          repository: https://github.com/operator-framework/operator-marketplace
+          support: Red Hat
+        name: marketplace-operator.v0.0.1
+        namespace: placeholder
+      spec:
+        customresourcedefinitions:
+          owned:
+          - description: Represents an OperatorSource.
+            displayName: Operator Source
+            kind: OperatorSource
+            name: operatorsources.marketplace.redhat.com
+            specDescriptors:
+            - description: The type of the operator source.
+              displayName: Type
+              path: type
+            - description: Points to the remote app registry server from where operator
+                manifests can be fetched.
+              displayName: Endpoint
+              path: endpoint
+            - description: 'The namespace in app registry.
+
+                Only operator manifests under this namespace will be visible.
+
+                Please note that this is not a k8s namespace.'
+              displayName: Registry Namespace
+              path: registryNamespace
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+          - description: Represents a CatalogSourceConfig object which is used to configure
+              a CatalogSource.
+            displayName: Catalog Source Config
+            kind: CatalogSourceConfig
+            name: catalogsourceconfigs.marketplace.redhat.com
+            specDescriptors:
+            - description: The namespace where the operators will be enabled.
+              displayName: Target Namespace
+              path: targetNamespace
+            - description: List of operator(s) which will be enabled in the target namespace
+              displayName: Packages
+              path: packages
+            statusDescriptors:
+            - description: Current status of the CatalogSourceConfig
+              displayName: Current Phase Name
+              path: currentPhase.phase.name
+            - description: Message associated with the current status
+              displayName: Current Phase Message
+              path: currentPhase.phase.message
+            version: v1alpha1
+        description: Marketplace is a gateway for users to consume off-cluster Operators
+          which will include Red Hat, ISV, optional OpenShift and community content.
+        displayName: marketplace-operator
+        install:
+          somefield: somevalue
+        installModes:
+        - supported: true
+          type: OwnNamespace
+        - supported: true
+          type: SingleNamespace
+        - supported: false
+          type: MultiNamespace
+        - supported: true
+          type: AllNamespaces
+        keywords:
+        - marketplace
+        - catalog
+        - olm
+        - admin
+        labels:
+          name: marketplace-operator
+        links:
+        - name: Markplace Operator Source Code
+          url: https://github.com/operator-framework/operator-marketplace
+        maintainers:
+        - email: aos-marketplace@redhat.com
+          name: AOS Marketplace Team
+        maturity: alpha
+        provider:
+          name: Red Hat
+        selector:
+          matchLabels:
+            name: marketplace-operator
+        version: 0.0.1
+  customResourceDefinitions: |
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents a CatalogSourceConfig.
+          displayName: Catalog Source Config
+        name: catalogsourceconfigs.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.targetNamespace
+          description: The namespace where the operators will be enabled
+          name: TargetNamespace
+          type: string
+        - JSONPath: .spec.packages
+          description: List of operator(s) which will be enabled in the target namespace
+          name: Packages
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the CatalogSourceConfig
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: CatalogSourceConfig
+          listKind: CatalogSourceConfigList
+          plural: catalogsourceconfigs
+          shortNames:
+          - csc
+          singular: catalogsourceconfig
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for a CatalogSourceConfig
+                properties:
+                  packages:
+                    description: Comma separated list of operator(s) without spaces
+                      which will be enabled in the target namespace
+                    type: string
+                  targetNamespace:
+                    description: The namespace where the operators will be enabled
+                    type: string
+                required:
+                - targetNamespace
+                - packages
+                type: object
+        version: v1alpha1
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        annotations:
+          description: Represents an OperatorSource.
+          displayName: Operator Source
+        name: operatorsources.marketplace.redhat.com
+      spec:
+        additionalPrinterColumns:
+        - JSONPath: .spec.type
+          description: The type of the OperatorSource
+          name: Type
+          type: string
+        - JSONPath: .spec.endpoint
+          description: The endpoint of the OperatorSource
+          name: Endpoint
+          type: string
+        - JSONPath: .spec.registryNamespace
+          description: App registry namespace
+          name: Registry
+          type: string
+        - JSONPath: .spec.displayName
+          description: Display (pretty) name to indicate the OperatorSource's name
+          name: DisplayName
+          type: string
+        - JSONPath: .spec.publisher
+          description: Publisher of the OperatorSource
+          name: Publisher
+          type: string
+        - JSONPath: .status.currentPhase.phase.name
+          description: Current status of the OperatorSource
+          name: Status
+          type: string
+        - JSONPath: .status.currentPhase.phase.message
+          description: Message associated with the current status
+          name: Message
+          type: string
+        - JSONPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+        group: marketplace.redhat.com
+        names:
+          kind: OperatorSource
+          listKind: OperatorSourceList
+          plural: operatorsources
+          shortNames:
+          - opsrc
+          singular: operatorsource
+        scope: Namespaced
+        validation:
+          openAPIV3Schema:
+            properties:
+              spec:
+                description: Spec for an OperatorSource.
+                properties:
+                  endpoint:
+                    description: Points to the remote app registry server from where
+                      operator manifests can be fetched.
+                    type: string
+                  registryNamespace:
+                    description: 'The namespace in app registry.
+
+                      Only operator manifests under this namespace will be visible.
+
+                      Please note that this is not a k8s namespace.'
+                    type: string
+                  type:
+                    description: The type of the OperatorSource
+                    pattern: appregistry
+                    type: string
+                required:
+                - type
+                - endpoint
+                - registryNamespace
+                type: object
+        version: v1alpha1
+  packages: |
+    - channels:
+      - currentCSV: marketplace-operator.v0.0.1
+        name: alpha
+      packageName: marketplace

--- a/tests/test_files/bundles/verification/valid.bundle.yaml
+++ b/tests/test_files/bundles/verification/valid.bundle.yaml
@@ -107,6 +107,14 @@ data:
           mediatype: image/png
         install:
           spec:
+            permissions:
+            - rules:
+              - apiGroups:
+                - ''
+                resources:
+                - 'serviceaccounts'
+                verbs:
+                - '*'
             clusterPermissions:
             - rules:
               - apiGroups:

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -30,6 +30,20 @@ def test_valid_bundles(bundle, expected_validation_results_dict):
     ("tests/test_files/bundles/verification/no-data-key.bundle.yaml",
         {'errors': ['Bundle does not contain any clusterServiceVersions.',
                     'Bundle does not contain any packages.'], 'warnings': []}),
+    ("tests/test_files/bundles/verification/csvinstallspecnotlists.invalid.bundle.yaml",
+        {'errors': ['csv spec.install.spec.deployments should be a list',
+                    'csv spec.install.spec.permissions should be a list',
+                    'csv spec.install.spec.clusterPermissions should be a list'],
+            'warnings': ['csv spec.icon not defined']}),
+    ("tests/test_files/bundles/verification/"
+        "csvmissinginstallattributes.invalid.bundle.yaml",
+        {'errors': ['csv spec.install.strategy not defined',
+                    'csv spec.install.spec not defined'],
+            'warnings': ['csv spec.icon not defined']}),
+    ("tests/test_files/bundles/verification/"
+        "csvinstallstrategywrongvalue.invalid.bundle.yaml",
+        {'errors': ["csv spec.install.strategy must be one of ['deployment']"],
+            'warnings': ['csv spec.icon not defined']}),
 ])
 def test_invalid_bundle(bundle, expected_validation_results_dict):
     valid, validation_results_dict = get_validation_results(bundle)


### PR DESCRIPTION
This adds ValidateCmd._csv_spec_install_validation() to validate required
and optional properties of spec.install.

Fixes #101 
Related to #100 