### PR TITLE
nest: Fix error for operators without CRDs

### DIFF
--- a/operatorcourier/nest.py
+++ b/operatorcourier/nest.py
@@ -58,18 +58,23 @@ def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
             yaml.dump(csv, outfile, default_flow_style=False)
             outfile.flush()
 
-        csv_crds = csv["spec"]["customresourcedefinitions"]["owned"]
-        for csv_crd in csv_crds:
-            crd_name = csv_crd["name"]
-            if crd_name in crds:
-                crd = crds[crd_name]
-                crdfile_name = os.path.join(csv_folder, '%s.crd.yaml' % crd_name)
-                with open(crdfile_name, 'w') as outfile:
-                    yaml.dump(crd, outfile, default_flow_style=False)
-                    outfile.flush()
-            else:
-                errors.append("CRD %s mentioned in CSV %s was not found in directory."
-                              % (crd_name, csv_name))
+        if "customresourcedefinitions" in csv["spec"]:
+            if "owned" in csv["spec"]["customresourcedefinitions"]:
+                csv_crds = csv["spec"]["customresourcedefinitions"]["owned"]
+                for csv_crd in csv_crds:
+                    if "name" not in csv_crd:
+                        errors.append("CSV %s has an owned CRD without a `name` field"
+                                      "defined" % csv_name)
+                    crd_name = csv_crd["name"]
+                    if crd_name in crds:
+                        crd = crds[crd_name]
+                        crdfile_name = os.path.join(csv_folder, '%s.crd.yaml' % crd_name)
+                        with open(crdfile_name, 'w') as outfile:
+                            yaml.dump(crd, outfile, default_flow_style=False)
+                            outfile.flush()
+                    else:
+                        errors.append("CRD %s mentioned in CSV %s was not found in"
+                                      "directory." % (crd_name, csv_name))
 
     # if no errors were encountered, lets create the real directory and populate it.
     if len(errors) == 0:

--- a/operatorcourier/nest.py
+++ b/operatorcourier/nest.py
@@ -24,8 +24,11 @@ def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
                 errors.append("Multiple packages in directory.")
         if yaml_type == "CustomResourceDefinition":
             crd = yaml.safe_load(yaml_string)
-            crd_name = crd["metadata"]["name"]
-            crds[crd_name] = crd
+            if "metadata" in crd and "name" in crd["metadata"]:
+                crd_name = crd["metadata"]["name"]
+                crds[crd_name] = crd
+            else:
+                errors.append("CRD has no `metadata.name` field defined")
         if yaml_type == "ClusterServiceVersion":
             csv = yaml.safe_load(yaml_string)
             csvs.append(csv)
@@ -37,44 +40,63 @@ def nest_bundles(yaml_files, registry_dir, temp_registry_dir):
         errors.append("No package file in directory.")
 
     # write the package file
-    package_name = package["packageName"]
-    packagefile_name = os.path.join(temp_registry_dir, '%s.package.yaml' % package_name)
-    with open(packagefile_name, 'w') as outfile:
-        yaml.dump(package, outfile, default_flow_style=False)
-        outfile.flush()
-
-    # now lets create a subdirectory for each version of the csv,
-    # and add all the relevant crds to it
-    for csv in csvs:
-        csv_name = csv["metadata"]["name"]
-        version = csv["spec"]["version"]
-        csv_folder = temp_registry_dir + "/" + version
-
-        if not os.path.exists(csv_folder):
-            os.makedirs(csv_folder)
-
-        csv_path = '%s/%s.clusterserviceversion.yaml' % (csv_folder, csv_name)
-        with open(csv_path, 'w') as outfile:
-            yaml.dump(csv, outfile, default_flow_style=False)
+    if "packageName" in package:
+        package_name = package["packageName"]
+        packagefile_name = os.path.join(temp_registry_dir, '%s.package.yaml'
+                                        % package_name)
+        with open(packagefile_name, 'w') as outfile:
+            yaml.dump(package, outfile, default_flow_style=False)
             outfile.flush()
 
-        if "customresourcedefinitions" in csv["spec"]:
-            if "owned" in csv["spec"]["customresourcedefinitions"]:
-                csv_crds = csv["spec"]["customresourcedefinitions"]["owned"]
-                for csv_crd in csv_crds:
-                    if "name" not in csv_crd:
-                        errors.append("CSV %s has an owned CRD without a `name` field"
-                                      "defined" % csv_name)
-                    crd_name = csv_crd["name"]
-                    if crd_name in crds:
-                        crd = crds[crd_name]
-                        crdfile_name = os.path.join(csv_folder, '%s.crd.yaml' % crd_name)
-                        with open(crdfile_name, 'w') as outfile:
-                            yaml.dump(crd, outfile, default_flow_style=False)
-                            outfile.flush()
-                    else:
-                        errors.append("CRD %s mentioned in CSV %s was not found in"
-                                      "directory." % (crd_name, csv_name))
+        # now lets create a subdirectory for each version of the csv,
+        # and add all the relevant crds to it
+        for csv in csvs:
+            if "metadata" not in csv:
+                errors.append("CSV has no `metadata` field defined")
+                continue
+            if "name" not in csv["metadata"]:
+                errors.append("CSV has no `metadata.name` field defined")
+                continue
+            csv_name = csv["metadata"]["name"]
+
+            if "spec" not in csv:
+                errors.append("CSV %s has no `spec` field defined" % csv_name)
+                continue
+            if "version" not in csv["spec"]:
+                errors.append("CSV %s has no `spec.version` field defined" % csv_name)
+                continue
+            version = csv["spec"]["version"]
+            csv_folder = temp_registry_dir + "/" + version
+
+            if not os.path.exists(csv_folder):
+                os.makedirs(csv_folder)
+
+            csv_path = '%s/%s.clusterserviceversion.yaml' % (csv_folder, csv_name)
+            with open(csv_path, 'w') as outfile:
+                yaml.dump(csv, outfile, default_flow_style=False)
+                outfile.flush()
+
+            if "customresourcedefinitions" in csv["spec"]:
+                if "owned" in csv["spec"]["customresourcedefinitions"]:
+                    csv_crds = csv["spec"]["customresourcedefinitions"]["owned"]
+                    for csv_crd in csv_crds:
+                        if "name" not in csv_crd:
+                            errors.append("CSV %s has an owned CRD without a `name`"
+                                          "field defined" % csv_name)
+                            continue
+                        crd_name = csv_crd["name"]
+                        if crd_name in crds:
+                            crd = crds[crd_name]
+                            crdfile_name = os.path.join(csv_folder, '%s.crd.yaml'
+                                                        % crd_name)
+                            with open(crdfile_name, 'w') as outfile:
+                                yaml.dump(crd, outfile, default_flow_style=False)
+                                outfile.flush()
+                        else:
+                            errors.append("CRD %s mentioned in CSV %s was not found"
+                                          "in directory." % (crd_name, csv_name))
+    else:
+        errors.append("Package file has no `packageName` field defined")
 
     # if no errors were encountered, lets create the real directory and populate it.
     if len(errors) == 0:

--- a/tests/test_files/bundles/nest/bundle2/svcat.package.yaml
+++ b/tests/test_files/bundles/nest/bundle2/svcat.package.yaml
@@ -1,0 +1,4 @@
+packageName: svcat
+channels:
+- name: alpha
+  currentCSV: svcat.v0.1.34

--- a/tests/test_files/bundles/nest/bundle2/svcat.v0.1.34.clusterserviceversion.yaml
+++ b/tests/test_files/bundles/nest/bundle2/svcat.v0.1.34.clusterserviceversion.yaml
@@ -1,0 +1,385 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  name: svcat.v0.1.34
+  namespace: placeholder
+  annotations:
+    categories: "OpenShift Optional"
+    certified: "false"
+    description: Service Catalog lets you provision cloud services directly from the comfort of native Kubernetes tooling. This project is in incubation to bring integration with service brokers to the Kubernetes ecosystem via the Open Service Broker API.
+    containerImage: quay.io/openshift/origin-service-catalog
+    createdAt: 2018-12-01T00:00:00Z
+    support: AOS Service Catalog
+spec:
+  displayName: Service Catalog
+  description: Service Catalog lets you provision cloud services directly from the comfort of native Kubernetes tooling. This project is in incubation to bring integration with service brokers to the Kubernetes ecosystem via the Open Service Broker API.
+  version: 0.1.34
+  keywords: ['catalog', 'service', 'svcat', 'osb', 'broker']
+  maintainers:
+  - name: Red Hat
+    email: openshift-operators@redhat.com
+  provider:
+    name: Red Hat
+  links:
+  - name: Documentation
+    url: https://svc-cat.io/docs
+  - name: Service Catalog
+    url: https://github.com/openshift/service-catalog
+
+  installModes:
+  - type: OwnNamespace
+    supported: true
+  - type: SingleNamespace
+    supported: true
+  - type: MultiNamespace
+    supported: false
+  - type: AllNamespaces
+    supported: true
+
+  install:
+    strategy: deployment
+    spec:
+      permissions:
+      - serviceAccountName: service-catalog-controller
+        rules:
+        - apiGroups:     [""]
+          resources:     ["configmaps"]
+          resourceNames: ["cluster-info"]
+          verbs:         ["get","create","list","watch","update"]
+        - apiGroups:     [""]
+          resources:     ["configmaps"]
+          verbs:         ["create", "list", "watch", "get", "update"]
+        - apiGroups:     [""]
+          resources:     ["configmaps"]
+          resourceNames: ["service-catalog-controller-manager"]
+          verbs:         ["get","update"]
+      clusterPermissions:
+      - serviceAccountName: service-catalog-controller
+        rules:
+        - apiGroups: [""]
+          resources: ["events"]
+          verbs:     ["create","patch","update"]
+        - apiGroups: [""]
+          resources: ["secrets"]
+          verbs:     ["get","create","update","delete","list","watch","patch"]
+        - apiGroups: [""]
+          resources: ["pods"]
+          verbs:     ["get","list","update", "patch", "watch", "delete", "initialize"]
+        - apiGroups: [""]
+          resources: ["namespaces"]
+          verbs:     ["get","list","watch"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["clusterserviceclasses"]
+          verbs:     ["get","list","watch","create","patch","update","delete"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["clusterserviceplans"]
+          verbs:     ["get","list","watch","create","patch","update","delete"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["clusterservicebrokers"]
+          verbs:     ["get","list","watch"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["serviceinstances","servicebindings"]
+          verbs:     ["get","list","watch", "update"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["clusterservicebrokers/status","clusterserviceclasses/status","clusterserviceplans/status","serviceinstances/status","serviceinstances/reference","servicebindings/status","servicebindings/finalizers"]
+          verbs:     ["update"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["serviceclasses"]
+          verbs:     ["get","list","watch","create","patch","update","delete"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["serviceplans"]
+          verbs:     ["get","list","watch","create","patch","update","delete"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["servicebrokers"]
+          verbs:     ["get","list","watch"]
+        - apiGroups: ["servicecatalog.k8s.io"]
+          resources: ["servicebrokers/status","serviceclasses/status","serviceplans/status"]
+          verbs:     ["update"]
+      - serviceAccountName: service-catalog-apiserver
+        rules:
+        - apiGroups:     [""]
+          resources:     ["configmaps"]
+          resourceNames: ["extension-apiserver-authentication"]
+          verbs:         ["get"]
+        - apiGroups: [""]
+          resources: ["namespaces"]
+          verbs:     ["get", "list", "watch"]
+        - apiGroups: ["admissionregistration.k8s.io"]
+          resources: ["validatingwebhookconfigurations"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["admissionregistration.k8s.io"]
+          resources: ["mutatingwebhookconfigurations"]
+          verbs: ["get", "list", "watch"]
+        - apiGroups: ["authentication.k8s.io"]
+          resources: ["tokenreviews"]
+          verbs: ["create"]
+        - apiGroups: ["authorization.k8s.io"]
+          resources: ["subjectaccessreviews"]
+          verbs: ["create"]
+      deployments:
+      - name: svcat-apiserver
+        spec:
+          replicas: 1
+          strategy:
+            type: RollingUpdate
+          selector:
+            matchLabels:
+              app: svcat-apiserver
+          template:
+            metadata:
+              labels:
+                app: svcat-apiserver
+            spec:
+              serviceAccountName: service-catalog-apiserver
+              containers:
+              - name: svcat-apiserver
+                image: quay.io/openshift/origin-service-catalog:v4.0.0
+                imagePullPolicy: IfNotPresent
+                command: ["/usr/bin/service-catalog"]
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 140Mi
+                  requests:
+                    cpu: 100m
+                    memory: 40Mi
+                args:
+                - apiserver
+                - --enable-admission-plugins
+                - "NamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck"
+                - --secure-port
+                - "5443"
+                - --etcd-servers
+                - http://localhost:2379
+                - -v
+                - "3"
+                - --feature-gates
+                - OriginatingIdentity=true
+                - --feature-gates
+                - NamespacedServiceBroker=true
+                ports:
+                - containerPort: 5443
+                volumeMounts:
+                - name: apiservice-cert
+                  mountPath: /var/run/kubernetes-service-catalog
+                readinessProbe:
+                  httpGet:
+                    port: 5443
+                    path: /healthz
+                    scheme: HTTPS
+                  failureThreshold: 1
+                  initialDelaySeconds: 30
+                  periodSeconds: 5
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                livenessProbe:
+                  httpGet:
+                    port: 5443
+                    path: /healthz
+                    scheme: HTTPS
+                  failureThreshold: 3
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+              - name: etcd
+                image: quay.io/coreos/etcd:latest
+                imagePullPolicy: Always
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 150Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+                env:
+                - name: ETCD_DATA_DIR
+                  value: /etcd-data-dir
+                command:
+                - /usr/local/bin/etcd
+                - --listen-client-urls
+                - http://0.0.0.0:2379
+                - --advertise-client-urls
+                - http://localhost:2379
+                ports:
+                - containerPort: 2379
+                volumeMounts:
+                - name: etcd-data-dir
+                  mountPath: /etcd-data-dir
+                readinessProbe:
+                  httpGet:
+                    port: 2379
+                    path: /health
+                  failureThreshold: 1
+                  initialDelaySeconds: 30
+                  periodSeconds: 5
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                livenessProbe:
+                  httpGet:
+                    port: 2379
+                    path: /health
+                  failureThreshold: 3
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+              volumes:
+              - name: etcd-data-dir
+                emptyDir: {}
+      - name: svcat-controller-manager
+        spec:
+          replicas: 1
+          strategy:
+            type: RollingUpdate
+          selector:
+            matchLabels:
+              app: svcat-controller-manager
+          template:
+            metadata:
+              labels:
+                app: svcat-controller-manager
+            spec:
+              serviceAccountName: service-catalog-controller
+              containers:
+              - name: svcat-controller-manager
+                image: quay.io/openshift/origin-service-catalog:v4.0.0
+                imagePullPolicy: IfNotPresent
+                command: ["/usr/bin/service-catalog"]
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 150Mi
+                  requests:
+                    cpu: 100m
+                    memory: 100Mi
+                env:
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                args:
+                - controller-manager
+                - --secure-port
+                - "8444"
+                - -v
+                - "3"
+                - --leader-election-namespace
+                - openshift-operators
+                - --leader-elect-resource-lock
+                - configmaps
+                - --cluster-id-configmap-namespace=openshift-operators
+                - --broker-relist-interval
+                - "5m"
+                - --feature-gates
+                - "OriginatingIdentity=true"
+                - --feature-gates
+                - "AsyncBindingOperations=true"
+                - --feature-gates
+                - "NamespacedServiceBroker=true"
+                ports:
+                - containerPort: 8444
+                readinessProbe:
+                  httpGet:
+                    port: 8444
+                    path: /healthz
+                    scheme: HTTPS
+                  failureThreshold: 1
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 2
+                livenessProbe:
+                  httpGet:
+                    port: 8444
+                    path: /healthz
+                    scheme: HTTPS
+                  failureThreshold: 3
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 2
+                # The following apiservice-cert is borrowed from the apiservice - it should be
+                # replaced with one specific for the controller manager.  How to create service
+                # for controller manager??
+                volumeMounts:
+                - name: apiservice-cert
+                  mountPath: /var/run/kubernetes-service-catalog
+              volumes:
+              - name: apiservice-cert
+                secret:
+                  defaultMode: 420
+                  items:
+                  - key: tls.crt
+                    path: apiserver.crt
+                  - key: tls.key
+                    path: apiserver.key
+                  secretName: v1beta1.servicecatalog.k8s.io-cert
+  apiservicedefinitions:
+    owned:
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ClusterServiceClass
+      name: clusterserviceclasses
+      displayName: ClusterServiceClass
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ClusterServicePlan
+      name: clusterserviceplans
+      displayName: ClusterServicePlan
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ClusterServiceBroker
+      name: clusterservicebrokers
+      displayName: ClusterServiceBroker
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ServiceInstance
+      name: serviceinstances
+      displayName: ServiceInstance
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ServiceBinding
+      name: servicebindings
+      displayName: ServiceBinding
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ServiceClass
+      name: serviceclasses
+      displayName: ServiceClass
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ServicePlan
+      name: serviceplans
+      displayName: ServicePlan
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443
+    - group: servicecatalog.k8s.io
+      version: v1beta1
+      kind: ServiceBroker
+      name: servicebrokers
+      displayName: ServiceBroker
+      description: A service catalog resource
+      deploymentName: svcat-apiserver
+      containerPort: 5443

--- a/tests/test_files/bundles/nest/bundle2result/0.1.34/svcat.v0.1.34.clusterserviceversion.yaml
+++ b/tests/test_files/bundles/nest/bundle2result/0.1.34/svcat.v0.1.34.clusterserviceversion.yaml
@@ -1,0 +1,530 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    categories: OpenShift Optional
+    certified: 'false'
+    containerImage: quay.io/openshift/origin-service-catalog
+    createdAt: 2018-12-01 00:00:00
+    description: Service Catalog lets you provision cloud services directly from the
+      comfort of native Kubernetes tooling. This project is in incubation to bring
+      integration with service brokers to the Kubernetes ecosystem via the Open Service
+      Broker API.
+    support: AOS Service Catalog
+  name: svcat.v0.1.34
+  namespace: placeholder
+spec:
+  apiservicedefinitions:
+    owned:
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ClusterServiceClass
+      group: servicecatalog.k8s.io
+      kind: ClusterServiceClass
+      name: clusterserviceclasses
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ClusterServicePlan
+      group: servicecatalog.k8s.io
+      kind: ClusterServicePlan
+      name: clusterserviceplans
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ClusterServiceBroker
+      group: servicecatalog.k8s.io
+      kind: ClusterServiceBroker
+      name: clusterservicebrokers
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ServiceInstance
+      group: servicecatalog.k8s.io
+      kind: ServiceInstance
+      name: serviceinstances
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ServiceBinding
+      group: servicecatalog.k8s.io
+      kind: ServiceBinding
+      name: servicebindings
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ServiceClass
+      group: servicecatalog.k8s.io
+      kind: ServiceClass
+      name: serviceclasses
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ServicePlan
+      group: servicecatalog.k8s.io
+      kind: ServicePlan
+      name: serviceplans
+      version: v1beta1
+    - containerPort: 5443
+      deploymentName: svcat-apiserver
+      description: A service catalog resource
+      displayName: ServiceBroker
+      group: servicecatalog.k8s.io
+      kind: ServiceBroker
+      name: servicebrokers
+      version: v1beta1
+  description: Service Catalog lets you provision cloud services directly from the
+    comfort of native Kubernetes tooling. This project is in incubation to bring integration
+    with service brokers to the Kubernetes ecosystem via the Open Service Broker API.
+  displayName: Service Catalog
+  install:
+    spec:
+      clusterPermissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resources:
+          - events
+          verbs:
+          - create
+          - patch
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - secrets
+          verbs:
+          - get
+          - create
+          - update
+          - delete
+          - list
+          - watch
+          - patch
+        - apiGroups:
+          - ''
+          resources:
+          - pods
+          verbs:
+          - get
+          - list
+          - update
+          - patch
+          - watch
+          - delete
+          - initialize
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - clusterserviceclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - clusterserviceplans
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - clusterservicebrokers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - serviceinstances
+          - servicebindings
+          verbs:
+          - get
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - clusterservicebrokers/status
+          - clusterserviceclasses/status
+          - clusterserviceplans/status
+          - serviceinstances/status
+          - serviceinstances/reference
+          - servicebindings/status
+          - servicebindings/finalizers
+          verbs:
+          - update
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - serviceclasses
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - serviceplans
+          verbs:
+          - get
+          - list
+          - watch
+          - create
+          - patch
+          - update
+          - delete
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - servicebrokers
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - servicecatalog.k8s.io
+          resources:
+          - servicebrokers/status
+          - serviceclasses/status
+          - serviceplans/status
+          verbs:
+          - update
+        serviceAccountName: service-catalog-controller
+      - rules:
+        - apiGroups:
+          - ''
+          resourceNames:
+          - extension-apiserver-authentication
+          resources:
+          - configmaps
+          verbs:
+          - get
+        - apiGroups:
+          - ''
+          resources:
+          - namespaces
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - validatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - admissionregistration.k8s.io
+          resources:
+          - mutatingwebhookconfigurations
+          verbs:
+          - get
+          - list
+          - watch
+        - apiGroups:
+          - authentication.k8s.io
+          resources:
+          - tokenreviews
+          verbs:
+          - create
+        - apiGroups:
+          - authorization.k8s.io
+          resources:
+          - subjectaccessreviews
+          verbs:
+          - create
+        serviceAccountName: service-catalog-apiserver
+      deployments:
+      - name: svcat-apiserver
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: svcat-apiserver
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                app: svcat-apiserver
+            spec:
+              containers:
+              - args:
+                - apiserver
+                - --enable-admission-plugins
+                - NamespaceLifecycle,DefaultServicePlan,ServiceBindingsLifecycle,ServicePlanChangeValidator,BrokerAuthSarCheck
+                - --secure-port
+                - '5443'
+                - --etcd-servers
+                - http://localhost:2379
+                - -v
+                - '3'
+                - --feature-gates
+                - OriginatingIdentity=true
+                - --feature-gates
+                - NamespacedServiceBroker=true
+                command:
+                - /usr/bin/service-catalog
+                image: quay.io/openshift/origin-service-catalog:v4.0.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: 5443
+                    scheme: HTTPS
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: svcat-apiserver
+                ports:
+                - containerPort: 5443
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /healthz
+                    port: 5443
+                    scheme: HTTPS
+                  initialDelaySeconds: 30
+                  periodSeconds: 5
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 140Mi
+                  requests:
+                    cpu: 100m
+                    memory: 40Mi
+                volumeMounts:
+                - mountPath: /var/run/kubernetes-service-catalog
+                  name: apiservice-cert
+              - command:
+                - /usr/local/bin/etcd
+                - --listen-client-urls
+                - http://0.0.0.0:2379
+                - --advertise-client-urls
+                - http://localhost:2379
+                env:
+                - name: ETCD_DATA_DIR
+                  value: /etcd-data-dir
+                image: quay.io/coreos/etcd:latest
+                imagePullPolicy: Always
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /health
+                    port: 2379
+                  initialDelaySeconds: 30
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                name: etcd
+                ports:
+                - containerPort: 2379
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /health
+                    port: 2379
+                  initialDelaySeconds: 30
+                  periodSeconds: 5
+                  successThreshold: 1
+                  timeoutSeconds: 5
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 150Mi
+                  requests:
+                    cpu: 100m
+                    memory: 50Mi
+                volumeMounts:
+                - mountPath: /etcd-data-dir
+                  name: etcd-data-dir
+              serviceAccountName: service-catalog-apiserver
+              volumes:
+              - emptyDir: {}
+                name: etcd-data-dir
+      - name: svcat-controller-manager
+        spec:
+          replicas: 1
+          selector:
+            matchLabels:
+              app: svcat-controller-manager
+          strategy:
+            type: RollingUpdate
+          template:
+            metadata:
+              labels:
+                app: svcat-controller-manager
+            spec:
+              containers:
+              - args:
+                - controller-manager
+                - --secure-port
+                - '8444'
+                - -v
+                - '3'
+                - --leader-election-namespace
+                - openshift-operators
+                - --leader-elect-resource-lock
+                - configmaps
+                - --cluster-id-configmap-namespace=openshift-operators
+                - --broker-relist-interval
+                - 5m
+                - --feature-gates
+                - OriginatingIdentity=true
+                - --feature-gates
+                - AsyncBindingOperations=true
+                - --feature-gates
+                - NamespacedServiceBroker=true
+                command:
+                - /usr/bin/service-catalog
+                env:
+                - name: K8S_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+                image: quay.io/openshift/origin-service-catalog:v4.0.0
+                imagePullPolicy: IfNotPresent
+                livenessProbe:
+                  failureThreshold: 3
+                  httpGet:
+                    path: /healthz
+                    port: 8444
+                    scheme: HTTPS
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 2
+                name: svcat-controller-manager
+                ports:
+                - containerPort: 8444
+                readinessProbe:
+                  failureThreshold: 1
+                  httpGet:
+                    path: /healthz
+                    port: 8444
+                    scheme: HTTPS
+                  initialDelaySeconds: 20
+                  periodSeconds: 10
+                  successThreshold: 1
+                  timeoutSeconds: 2
+                resources:
+                  limits:
+                    cpu: 100m
+                    memory: 150Mi
+                  requests:
+                    cpu: 100m
+                    memory: 100Mi
+                volumeMounts:
+                - mountPath: /var/run/kubernetes-service-catalog
+                  name: apiservice-cert
+              serviceAccountName: service-catalog-controller
+              volumes:
+              - name: apiservice-cert
+                secret:
+                  defaultMode: 420
+                  items:
+                  - key: tls.crt
+                    path: apiserver.crt
+                  - key: tls.key
+                    path: apiserver.key
+                  secretName: v1beta1.servicecatalog.k8s.io-cert
+      permissions:
+      - rules:
+        - apiGroups:
+          - ''
+          resourceNames:
+          - cluster-info
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - create
+          - list
+          - watch
+          - update
+        - apiGroups:
+          - ''
+          resources:
+          - configmaps
+          verbs:
+          - create
+          - list
+          - watch
+          - get
+          - update
+        - apiGroups:
+          - ''
+          resourceNames:
+          - service-catalog-controller-manager
+          resources:
+          - configmaps
+          verbs:
+          - get
+          - update
+        serviceAccountName: service-catalog-controller
+    strategy: deployment
+  installModes:
+  - supported: true
+    type: OwnNamespace
+  - supported: true
+    type: SingleNamespace
+  - supported: false
+    type: MultiNamespace
+  - supported: true
+    type: AllNamespaces
+  keywords:
+  - catalog
+  - service
+  - svcat
+  - osb
+  - broker
+  links:
+  - name: Documentation
+    url: https://svc-cat.io/docs
+  - name: Service Catalog
+    url: https://github.com/openshift/service-catalog
+  maintainers:
+  - email: openshift-operators@redhat.com
+    name: Red Hat
+  provider:
+    name: Red Hat
+  version: 0.1.34

--- a/tests/test_files/bundles/nest/bundle2result/svcat.package.yaml
+++ b/tests/test_files/bundles/nest/bundle2result/svcat.package.yaml
@@ -1,0 +1,4 @@
+channels:
+- currentCSV: svcat.v0.1.34
+  name: alpha
+packageName: svcat

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -19,3 +19,20 @@ def test_nest_default():
 
         dcmp = dircmp(registry_dir, expected_result)
         assert(len(dcmp.diff_files) == 0)
+
+
+def test_nest_no_crds():
+    with TemporaryDirectory() as registry_dir:
+        expected_result = "tests/test_files/bundles/nest/bundle2result"
+        folder_to_nest = "tests/test_files/bundles/nest/bundle2"
+
+        yaml_files = []
+        for filename in os.listdir(folder_to_nest):
+            with open(folder_to_nest + "/" + filename) as f:
+                yaml_files.append(f.read())
+
+        with TemporaryDirectory() as temp_dir:
+            nest_bundles(yaml_files, registry_dir, temp_dir)
+
+        dcmp = dircmp(registry_dir, expected_result)
+        assert(len(dcmp.diff_files) == 0)


### PR DESCRIPTION
- Add checks for object pathes in nest.py before accessing values
- Add test case for test_nest.py for operator without CRDs

Fixes an issue seen in CI on this PR: https://github.com/operator-framework/community-operators/pull/278
The CI runs `operator-courier nest` on operators, but for this operator it errors out with the obscure message`'customresourcedefinitions'`. This fix adds more field checks into the nest function, and handles operators without owned CRDs.
CI log: https://travis-ci.com/operator-framework/community-operators/builds/108167507#L454