### PR TITLE
Raise error after validation is written to file

### DIFF
--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -14,6 +14,7 @@ from operatorcourier.verified_manifest import VerifiedManifest
 from operatorcourier.push import PushCmd
 from operatorcourier.nest import nest_bundles
 from operatorcourier.flatten import flatten_bundles
+from operatorcourier.errors import OpCourierBadBundle
 
 logger = logging.getLogger(__name__)
 
@@ -49,6 +50,10 @@ def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False,
 
     if validation_output:
         verified_manifest.write_validation_to_file(validation_output)
+
+    if not verified_manifest.is_valid:
+        raise OpCourierBadBundle("Resulting bundle is invalid, "
+                                 "input yaml is improperly defined.", {})
 
     return verified_manifest
 

--- a/operatorcourier/verified_manifest.py
+++ b/operatorcourier/verified_manifest.py
@@ -30,6 +30,7 @@ class VerifiedManifest:
         self.bundle_dict = None
         self.__validation_dict = \
             self.get_validation_dict_from_manifests(manifests, ui_validate_io, repository)
+        self.is_valid = False if self.__validation_dict['errors'] else True
 
     def get_manifest_files_content(self, file_paths):
         """
@@ -136,12 +137,6 @@ class VerifiedManifest:
                 .validate(bundle_dict, repository)
             for log_level, msg_list in validation_dict_temp.items():
                 validation_dict[log_level].extend(msg_list)
-
-        if validation_dict['errors']:
-            logger.error("Bundle failed validation.")
-            raise OpCourierBadBundle(
-                "Resulting bundle is invalid, input yaml is improperly defined.",
-                validation_info=validation_dict)
 
         if not self.nested:
             self.bundle_dict = bundle_dict

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,7 @@ def test_make_bundle(directory, expected):
         expected_bundle = yaml.safe_load(expected_file)
     assert unformat_bundle(verified_manifest.bundle) == unformat_bundle(expected_bundle)
     assert not verified_manifest.nested
+    assert verified_manifest.is_valid
     assert hasattr(verified_manifest, 'bundle')
 
 
@@ -41,6 +42,7 @@ def test_make_bundle_with_yaml_list(yaml_files, expected):
         expected_bundle = yaml.safe_load(expected_file)
     assert unformat_bundle(verified_manifest.bundle) == unformat_bundle(expected_bundle)
     assert not verified_manifest.nested
+    assert verified_manifest.is_valid
     assert hasattr(verified_manifest, 'bundle')
 
 
@@ -54,20 +56,11 @@ def test_make_bundle_invalid(yaml_files):
         with open(file, "r") as yaml_file:
             yamls.append(yaml_file.read())
 
-    with pytest.raises(OpCourierBadBundle) as e_info:
+    with pytest.raises(OpCourierBadBundle) as err:
         api.build_and_verify(yamls=yamls)
 
-    e = e_info.value
-    e_msg = "Resulting bundle is invalid, input yaml is improperly defined."
-    e_dict = {
-        "warnings": [
-            "csv metadata.annotations not defined.",
-            "csv spec.icon not defined"
-        ],
-        "errors": ["Bundle does not contain any packages."]
-    }
-    assert str(e) == e_msg
-    assert e.validation_info == e_dict
+    assert str(err.value) == "Resulting bundle is invalid, " \
+                             "input yaml is improperly defined."
 
 
 @pytest.mark.parametrize('nested_source_dir', [
@@ -77,6 +70,7 @@ def test_make_bundle_invalid(yaml_files):
 def test_valid_nested_bundles(nested_source_dir):
     verified_manifest = api.build_and_verify(source_dir=nested_source_dir)
     assert verified_manifest.nested
+    assert verified_manifest.is_valid
 
 
 # Made changes to etcdoperator.v0.9.0.clusterserviceversion.yaml and
@@ -85,20 +79,8 @@ def test_valid_nested_bundles(nested_source_dir):
     'tests/test_files/bundles/api/etcd_invalid_nested_bundle',
 ])
 def test_invalid_nested_bundles(nested_source_dir):
-    with pytest.raises(OpCourierBadBundle) as e_info:
+    with pytest.raises(OpCourierBadBundle) as err:
         api.build_and_verify(source_dir=nested_source_dir, repository='invalid_repo')
 
-    e = e_info.value
-    e_msg = "Resulting bundle is invalid, input yaml is improperly defined."
-    expected_errors = {
-        'csv apiVersion not defined.',
-        'csv spec.installModes not defined',
-        'The packageName (etcd) in bundle does not match repository name '
-        '(invalid_repo) provided as command line argument.',
-        'The packageName (etcd) in bundle does not match repository name '
-        '(invalid_repo) provided as command line argument.',
-        'The packageName (etcd) in bundle does not match repository name '
-        '(invalid_repo) provided as command line argument.',
-    }
-    assert str(e) == e_msg
-    assert set(e.validation_info['errors']) == expected_errors
+    assert str(err.value) == "Resulting bundle is invalid, " \
+                             "input yaml is improperly defined."


### PR DESCRIPTION
Currently when we initialize the `VerifiedManifest` object and validate the input yamls, if the validation fails, `OpCourierBadBundle` Error will be raised before the warnings/errors are written to a file (if the user specifies this option).

We need to move the code raising the error after the warnings/errors have been written to a file.