### PR TITLE
Use os.path.relpath to calculate relative paths

### DIFF
--- a/operatorcourier/nest.py
+++ b/operatorcourier/nest.py
@@ -35,10 +35,9 @@ def nest_bundles(source_dir, output_dir):
             manifest_files_path.extend(crd_csv_file_paths)
 
         # copy all manifest files to output_dir with folder structure preserved
-        source_dir = os.path.join(source_dir, '')  # adds a trailing slash if missing
         os.makedirs(output_dir, exist_ok=True)
         for file_path in manifest_files_path:
-            file_path_relative = file_path[len(source_dir):]
+            file_path_relative = os.path.relpath(file_path, source_dir)
             output_file_path = os.path.join(output_dir, file_path_relative)
             os.makedirs(os.path.dirname(output_file_path), exist_ok=True)
             copyfile(file_path, output_file_path)

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -28,9 +28,8 @@ def _get_dir_file_paths(source_dir):
     """
     file_paths = set()
 
-    source_dir = os.path.join(source_dir, '')  # adds a trailing slash if missing
     for root_path, dir_names, file_names in os.walk(source_dir):
-        dir_path_relative = root_path[len(source_dir):]
+        dir_path_relative = os.path.relpath(root_path, source_dir)
         for file_name in file_names:
             file_paths.add(os.path.join(dir_path_relative, file_name))
     return file_paths


### PR DESCRIPTION
Fixing [Martin's comment](https://github.com/operator-framework/operator-courier/pull/125#discussion_r283839729) on previous PR.