### PR TITLE
Add "Application Runtime" as a valid category

### DIFF
--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -536,6 +536,7 @@ class ValidateCmd():
         def is_category(category):
             valid_categories = [
                 "AI/Machine Learning",
+                "Application Runtime",
                 "Big Data",
                 "Cloud Provider",
                 "Developer Tools",


### PR DESCRIPTION
This category could be used for operators managing application runtimes such as applications servers or some application frameworks.

An example of such an operator is the proposed WildFly Operator at https://github.com/operator-framework/community-operators/pull/371