### PR TITLE
Add filename to warnings and errors

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -10,7 +10,10 @@ def test_create_bundle():
     yamls = []
     for path in paths:
         with open(path) as f:
-            yamls.append(f.read())
+            yaml_data = f.read()
+            filename = ""
+            yaml = (filename, yaml_data)
+            yamls.append(yaml)
 
     bundle = BuildCmd().build_bundle(yamls)
     assert bool(bundle["data"]["packages"]) is True


### PR DESCRIPTION
Problem:
Command line output logs are hard to read because, in the case where
there are many operator yamls, there is no obvious output as to which
file caused the error in question.

Solution:
Add file references and relative file paths to the output logs.
Update build_bundle() to take the filename metadata so that the
validator can use the new metadata field