### PR TITLE
Disable unusable `push` integration tests

### DIFF
--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -3,9 +3,3 @@
 echo "Running integration tests triggered by $TRAVIS_EVENT_TYPE..."
 
 pytest tests/integration/test_verify.py
-
-# only runs if the Travis build is triggered by a cronjob, or
-# $QUAY_NAMESPACE and $QUAY_ACCESS_TOKEN is set locally
-if [[ $TRAVIS_EVENT_TYPE == 'cron' ]] || (! [[ -z $QUAY_NAMESPACE ]] && ! [[ -z $QUAY_ACCESS_TOKEN ]]); then
-  pytest tests/integration/test_push.py
-fi


### PR DESCRIPTION
Currently, there are some integration tests that run against the `master` branch. These tests always fail because they are not properly configured (due to required hidden credentials). Deleting the hook for these integration tests.

In the future, these can be reenabled if/when we decide to invest in a way to hide the credentials.