### PR TITLE
Run from root dir

### DIFF
--- a/operatorcourier/build.py
+++ b/operatorcourier/build.py
@@ -20,10 +20,15 @@ class BuildCmd():
         """
         :param path: the path of the file
         :return: the file name along with its parent folder
+        If the file is in the root directory from where it was
+        called, just return the input path.
         """
         path = os.path.normpath(path)
         parts = path.split(os.sep)
-        return os.path.join(parts[-2], parts[-1])
+        if len(parts) > 1:
+            return os.path.join(parts[-2], parts[-1])
+        else:
+            return path
 
     def _updateBundle(self, operatorBundle, file_name, yaml_string):
         # Determine which operator file type the yaml is

--- a/tests/integration/test_verify.py
+++ b/tests/integration/test_verify.py
@@ -107,3 +107,16 @@ def test_verify_invalid_sources(source_dir, error_message):
 
     outputs = process.stdout.read().decode("utf-8")
     assert error_message in outputs
+
+
+@pytest.mark.parametrize('source_dir', [
+    "valid_yamls_with_single_crd",
+])
+def test_verify_valid_sources_root_dir(source_dir):
+    process = subprocess.Popen(f'operator-courier verify {source_dir}',
+                               shell=True,
+                               stdout=subprocess.PIPE,
+                               stderr=subprocess.STDOUT,
+                               cwd="./tests/test_files/yaml_source_dir/")
+    exit_code = process.wait()
+    assert exit_code == 0


### PR DESCRIPTION
Problem:
Since the addition of the file name and path to verification logs, a
bug was introduced that prevented users from running `verify`
or anything that calls the `build_and_verify` api method when
running in the same directory that manifests are located.

Solution:
Update the `_get_relative_path()` function in build.py to return
the input path parameter when the path cannot be split on
os path seperators

Added integration test to run  verify using a working directory
matching the manifests path