### PR TITLE
Add validation details into raised exception

### DIFF
--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -52,7 +52,8 @@ def build_and_verify(source_dir=None, yamls=None, ui_validate_io=False,
 
     if not verified_manifest.is_valid:
         raise OpCourierBadBundle("Resulting bundle is invalid, "
-                                 "input yaml is improperly defined.", {})
+                                 "input yaml is improperly defined.",
+                                 verified_manifest.validation_dict)
 
     return verified_manifest
 

--- a/operatorcourier/verified_manifest.py
+++ b/operatorcourier/verified_manifest.py
@@ -1,4 +1,5 @@
 import os
+import copy
 import logging
 import json
 from operatorcourier.build import BuildCmd
@@ -20,6 +21,10 @@ class VerifiedManifest:
             raise AttributeError('VerifiedManifest does not have the bundle property '
                                  'in nested cases.')
         return format_bundle(self.bundle_dict)
+
+    @property
+    def validation_dict(self):
+        return copy.deepcopy(self.__validation_dict)
 
     def __init__(self, source_dir, yamls, ui_validate_io, repository):
         self.nested = False

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -48,11 +48,19 @@ def test_make_bundle_with_yaml_list(yaml_files, expected):
     assert hasattr(verified_manifest, 'bundle')
 
 
-@pytest.mark.parametrize('yaml_files', [
-    ["tests/test_files/bundles/api/valid_flat_bundle/crd.yml",
-     "tests/test_files/bundles/api/valid_flat_bundle/csv.yaml"]
+@pytest.mark.parametrize('yaml_files,validation_info', [
+    (
+        [
+            "tests/test_files/bundles/api/valid_flat_bundle/crd.yml",
+            "tests/test_files/bundles/api/valid_flat_bundle/csv.yaml"
+        ], {
+            'errors': ['Bundle does not contain any packages.'],
+            'warnings': ['csv metadata.annotations not defined.',
+                         'csv spec.icon not defined']
+        }
+    ),
 ])
-def test_make_bundle_invalid(yaml_files):
+def test_make_bundle_invalid(yaml_files, validation_info):
     yamls = []
     for file in yaml_files:
         with open(file, "r") as yaml_file:
@@ -63,6 +71,7 @@ def test_make_bundle_invalid(yaml_files):
 
     assert str(err.value) == "Resulting bundle is invalid, " \
                              "input yaml is improperly defined."
+    assert err.value.validation_info == validation_info
 
 
 @pytest.mark.parametrize('nested_source_dir', [


### PR DESCRIPTION
When manifests are invalid operator courier should provide details
about errors.

Fixes: #146

Signed-off-by: Martin Bašti <mbasti@redhat.com>