### PR TITLE
Include a randomized container folder in the tarred bundle

### DIFF
--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -86,7 +86,6 @@ def build_verify_and_push(namespace, repository, revision, token,
     """
     verified_manifest = build_and_verify(source_dir, yamls, repository=repository,
                                          validation_output=validation_output)
-
     if not verified_manifest.nested:
         with TemporaryDirectory(prefix=repository+"-") as temp_dir:
             with open(os.path.join(temp_dir, 'bundle.yaml'), 'w') as outfile:

--- a/operatorcourier/api.py
+++ b/operatorcourier/api.py
@@ -88,12 +88,12 @@ def build_verify_and_push(namespace, repository, revision, token,
                                          validation_output=validation_output)
 
     if not verified_manifest.nested:
-        with TemporaryDirectory() as temp_dir:
+        with TemporaryDirectory(prefix=repository+"-") as temp_dir:
             with open(os.path.join(temp_dir, 'bundle.yaml'), 'w') as outfile:
                 yaml.dump(verified_manifest.bundle, outfile, default_flow_style=False)
             PushCmd().push(temp_dir, namespace, repository, revision, token)
     else:
-        with TemporaryDirectory() as temp_dir:
+        with TemporaryDirectory(prefix=repository+"-") as temp_dir:
             copy_tree(source_dir, temp_dir)
             PushCmd().push(temp_dir, namespace, repository, revision, token)
 

--- a/operatorcourier/push.py
+++ b/operatorcourier/push.py
@@ -39,7 +39,7 @@ class PushCmd():
         with TemporaryDirectory() as temp_dir:
             tarfile_name = os.path.join(temp_dir, "%s.tar.gz" % repository)
             with tarfile.open(tarfile_name, "w:gz") as tar:
-                tar.add(bundle_dir, "")
+                tar.add(bundle_dir, os.path.basename(bundle_dir))
             with open(tarfile_name, "rb") as tarball:
                 result = tarball.read()
             result64 = base64.b64encode(result).decode("utf-8")

--- a/tests/test_push.py
+++ b/tests/test_push.py
@@ -1,0 +1,40 @@
+import base64
+import tarfile
+
+import pytest
+import os
+from tempfile import TemporaryDirectory
+from distutils.dir_util import copy_tree
+from operatorcourier.push import PushCmd
+
+
+@pytest.mark.parametrize('bundle_dir', [
+    "tests/test_files/bundles/api/etcd_valid_nested_bundle"
+])
+def test_create_base64_bundle(bundle_dir):
+    with TemporaryDirectory() as scratch:
+        directory_name = "directory-abcd"
+        # make a subdirectory with a known name so that the bundle is always the same
+        inpath = os.path.join(scratch, directory_name)
+        os.mkdir(inpath)
+
+        copy_tree(bundle_dir, inpath)
+        out = PushCmd()._create_base64_bundle(inpath, "repo")
+
+        outpath = os.path.join(scratch, "out")
+        os.mkdir(outpath)
+
+        # write the output tar
+        tardata = base64.b64decode(out)
+        tarfile_name = os.path.join(outpath, "bundle.tar.gz")
+        with open(tarfile_name, "wb") as bundle:
+            bundle.write(tardata)
+
+        # uncompress the bundle
+        with tarfile.open(tarfile_name) as bundle:
+            bundle.extractall(path=outpath)
+
+        outfiles = os.listdir(outpath)
+
+        # ensure the surrouding directory was packed into the tar archive
+        assert directory_name in outfiles


### PR DESCRIPTION
This will help prevent collisions when untarring into the same directory.

Before:

```
├── 0.6
│   ├── etcdcluster.crd.yaml
│   └── etcdoperator.clusterserviceversion.yaml
├── 0.8
│   ├── etcdbackup.crd.yaml
│   ├── etcdcluster.crd.yaml
│   ├── etcdoperator.v0.9.0.clusterserviceversion.yaml
│   └── etcdrestore.crd.yaml
├── 0.9
│   ├── etcdbackup.crd.yaml
│   ├── etcdcluster.crd.yaml
│   ├── etcdoperator.v0.9.2.clusterserviceversion.yaml
│   └── etcdrestore.crd.yaml
└── etcd.package.yaml
```

After (example with two operators with overlapping versions)
```
tree downloaded                                                                                           1 ↵
downloaded
├── etcd-wmrnyuth
│   ├── 0.6
│   │   ├── etcdcluster.crd.yaml
│   │   └── etcdoperator.clusterserviceversion.yaml
│   ├── 0.8
│   │   ├── etcdbackup.crd.yaml
│   │   ├── etcdcluster.crd.yaml
│   │   ├── etcdoperator.v0.9.0.clusterserviceversion.yaml
│   │   └── etcdrestore.crd.yaml
│   ├── 0.9
│   │   ├── etcdbackup.crd.yaml
│   │   ├── etcdcluster.crd.yaml
│   │   ├── etcdoperator.v0.9.2.clusterserviceversion.yaml
│   │   └── etcdrestore.crd.yaml
│   └── etcd.package.yaml
└── notetcd-1rrw4cow
    ├── 0.6
    │   ├── etcdcluster.crd.yaml
    │   └── etcdoperator.clusterserviceversion.yaml
    ├── 0.8
    │   ├── etcdbackup.crd.yaml
    │   ├── etcdcluster.crd.yaml
    │   ├── etcdoperator.v0.9.0.clusterserviceversion.yaml
    │   └── etcdrestore.crd.yaml
    ├── 0.9
    │   ├── etcdbackup.crd.yaml
    │   ├── etcdoperator.v0.9.2.clusterserviceversion.yaml
    │   ├── etcdrestore.crd.yaml
    │   └── notcluster.crd.yaml
    └── notetcd.package.yaml
```

Tested with appregistry-server release-4.1 and master.

