### PR TITLE
test: OMPS integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Operator Courier is currently supported on Python 3.6 and above.
   ```bash
   $ pip3 install operator-courier==2.0.1
   ```
-    
+
 - To upgrade an existing operator-courier release:
 
   ```bash
@@ -93,27 +93,47 @@ def main():
 ## Building and running the tool locally with pip
 ```bash
 $ pip3 install --user .
-
 $ operator-courier
 ```
 
 ## Testing
 
-### Running the tests
+### Unit tests
 
 [Install tox](https://tox.readthedocs.io/en/latest/install.html) and run:
 
-```bash 
+```bash
 $ tox
 ```
 
 This will run the tests with several versions of Python 3, measure coverage,
 and run flake8 for code linting.
 
-## Building the docker image
+### Integration tests
+
+Before running integration tests, you must have write access credentials to a [quay.io](https://quay.io) namespace. See the [authentication](#authentication) section for more information.
+
+First, build the integration docker image:
+
+```sh
+$ docker build -f omps-integration.Dockerfile -t operator-courier-integration .
 ```
-docker build Dockerfile -t $TAG
-docker run $TAG operator-courier
+
+Then run the tests inside a container:
+
+```sh
+$ docker run \
+  -e QUAY_NAMESPACE="$QUAY_NAMESPACE" \
+  -e QUAY_ACCESS_TOKEN="$QUAY_ACCESS_TOKEN" \
+  operator-courier-integration:latest \
+  /operator-courier/run_integration_tests.sh
+```
+
+## Building the docker image
+
+```sh
+$ docker build -f Dockerfile -t $TAG
+$ docker run $TAG operator-courier
 ```
 
 For further details, please see the [contribution guide](docs/contributing.md).

--- a/omps-integration.Dockerfile
+++ b/omps-integration.Dockerfile
@@ -1,0 +1,17 @@
+ARG OMPS_VERSION=latest
+FROM quay.io/operator-manifests/omps:${OMPS_VERSION}
+
+# Install operator-courier.
+USER 0
+RUN pip3 install koji
+COPY . /repo
+WORKDIR /repo
+RUN pip3 install -U .
+RUN rm -rf /repo
+
+# Re-install omps with this version of operator-courier.
+WORKDIR /src
+RUN pip3 install -U --no-deps .
+
+USER 1001
+ENTRYPOINT docker/install-ca.sh && gunicorn-3 --workers ${WORKERS_NUM} --timeout ${WORKER_TIMEOUT} --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance omps.app:app

--- a/omps-integration.Dockerfile
+++ b/omps-integration.Dockerfile
@@ -3,15 +3,14 @@ FROM quay.io/operator-manifests/omps:${OMPS_VERSION}
 
 # Install operator-courier.
 USER 0
-RUN pip3 install koji
-COPY . /repo
-WORKDIR /repo
+RUN pip3 install koji tox
+COPY . /operator-courier
+WORKDIR /operator-courier
 RUN pip3 install -U .
-RUN rm -rf /repo
 
 # Re-install omps with this version of operator-courier.
 WORKDIR /src
 RUN pip3 install -U --no-deps .
 
-USER 1001
-ENTRYPOINT docker/install-ca.sh && gunicorn-3 --workers ${WORKERS_NUM} --timeout ${WORKER_TIMEOUT} --bind 0.0.0.0:8080 --access-logfile=- --enable-stdio-inheritance omps.app:app
+# Override parent entrypoint(s).
+ENTRYPOINT []

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,8 +1,75 @@
 #!/usr/bin/env bash
 
-# Note: env QUAY_NAMESPACE, QUAY_ACCESS_TOKEN, and OMPS_HOST are required by
-# integration tests.
+# Note: env QUAY_NAMESPACE, QUAY_ACCESS_TOKEN, and OMPS_HOST, or their
+# argument equivalents, are required by integration tests.
 
+function parse_docker_quay_auth() {
+  python3 -c "import sys, json; \
+  print(json.load(sys.stdin)['auths']['quay.io']['auth'])"
+}
+
+function parse_args() {
+  while (( "$#" )); do
+    case "$1" in
+      --quay-namespace)
+        export QUAY_NAMESPACE="$2"
+        shift 2
+        ;;
+      --quay-access_token)
+        export QUAY_ACCESS_TOKEN="$2"
+        shift 2
+        ;;
+      --docker-config)
+        export QUAY_ACCESS_TOKEN="basic $(cat "$2" | parse_docker_quay_auth)"
+        shift 2
+        ;;
+      --omps-host)
+        export OMPS_HOST="$2"
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      -*|--*=)
+        echo "Error: Unsupported flag $1" >&2
+        exit 1
+        ;;
+    esac
+  done
+
+  if [[ -z "$OMPS_HOST" ]]; then
+    export OMPS_HOST="http://0.0.0.0:8080"
+  fi
+  echo "Running OMPS at \"$OMPS_HOST\""
+  if [[ -z "$QUAY_NAMESPACE" ]]; then
+    export QUAY_NAMESPACE="operator-manifests"
+  fi
+  echo "Using QUAY_NAMESPACE \"$QUAY_NAMESPACE\""
+  if [[ -z "$QUAY_ACCESS_TOKEN" ]]; then
+    echo "One of QUAY_ACCESS_TOKEN, --quay-access-token, or --docker-config must be set for integration tests"
+    exit 1
+  fi
+}
+
+set -e
+
+parse_args $@
+
+# Runs inside of omps repo dir in integration container.
+if [[ ! -d omps ]]; then
+  echo "Integration tests must run in the integration Docker container"
+  exit 1
+fi
+./docker/install-ca.sh
+gunicorn-3 \
+  --daemon \
+  --workers $WORKERS_NUM \
+  --timeout $WORKER_TIMEOUT \
+  --bind $(echo "$OMPS_HOST" | sed -E 's|(.+://)(.+)|\2|') \
+  --access-logfile=- \
+  --enable-stdio-inheritance \
+  omps.app:app
+
+pushd "/operator-courier"
 TOXENV=py37 tox -e integration
-
-# TODO: create Subscription for OLM to pull and run.

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
-echo "Running integration tests triggered by $TRAVIS_EVENT_TYPE..."
+# Note: env QUAY_NAMESPACE, QUAY_ACCESS_TOKEN, and OMPS_HOST are required by
+# integration tests.
 
-pytest tests/integration/test_verify.py
+TOXENV=py37 tox -e integration
+
+# TODO: create Subscription for OLM to pull and run.

--- a/scripts/install-test-dependencies
+++ b/scripts/install-test-dependencies
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -e
+
+pip3 install tox

--- a/scripts/install-test-dependencies
+++ b/scripts/install-test-dependencies
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-pip3 install tox

--- a/tests/integration/test_omps.py
+++ b/tests/integration/test_omps.py
@@ -27,7 +27,7 @@ def test_push_valid_sources(source_dir, repository_name):
     with ZipFile(zip_path, 'w') as zipper:
         zipdir(source_dir, zipper)
 
-    upload_url = '%s/v2/%s/zipfile/%s' % (test_omps_host, quay_namespace, release_version)
+    upload_url = get_upload_url(release_version)
     headers = {'Authorization': quay_access_token}
     files = {'file': open(zip_path, 'rb')}
 
@@ -54,7 +54,7 @@ def test_push_invalid_sources(source_dir, repository_name,
     with ZipFile(zip_path, 'w') as zipper:
         zipdir(source_dir, zipper)
 
-    upload_url = '%s/v2/%s/zipfile/%s' % (test_omps_host, quay_namespace, release_version)
+    upload_url = get_upload_url(release_version)
     headers = {'Authorization': quay_access_token}
     files = {'file': open(zip_path, 'rb')}
 
@@ -66,6 +66,16 @@ def test_push_invalid_sources(source_dir, repository_name,
     ensure_zipfile_removed(zip_path)
 
 
+def get_upload_url(release_version):
+    return '%s/v2/%s/zipfile/%s' % (test_omps_host, quay_namespace,
+                                    release_version)
+
+
+def get_delete_url(repository_name, release_version):
+    return '%s/v2/%s/%s/%s' % (test_omps_host, quay_namespace,
+                               repository_name, release_version)
+
+
 def zipdir(dir, zipf):
     for root, dirs, files in walk(dir):
         for file in files:
@@ -75,8 +85,7 @@ def zipdir(dir, zipf):
 
 
 def ensure_application_release_removed_omps(repository_name, release_version):
-    delete_url = '%s/v2/%s/%s/%s' % (test_omps_host, quay_namespace,
-                                     repository_name, release_version)
+    delete_url = get_delete_url(repository_name, release_version)
     headers = {'Authorization': quay_access_token}
 
     res = requests.delete(delete_url, headers=headers)

--- a/tests/integration/test_omps.py
+++ b/tests/integration/test_omps.py
@@ -1,0 +1,87 @@
+import pytest
+import requests
+from os import getenv, path, walk, remove
+from random import randint
+from zipfile import ZipFile
+
+quay_namespace = getenv('QUAY_NAMESPACE')
+quay_access_token = getenv('QUAY_ACCESS_TOKEN')
+test_omps_host = getenv('OMPS_HOST')
+
+
+def setup_module():
+    healthz_url = '%s/v2/health/ping' % (test_omps_host)
+    res = requests.get(healthz_url)
+    assert res.status_code == 200
+
+
+@pytest.mark.parametrize('source_dir,repository_name', [
+    ('tests/test_files/bundles/api/etcd_valid_nested_bundle', 'etcd'),
+    ('tests/test_files/bundles/api/valid_flat_bundle', 'marketplace'),
+])
+def test_push_valid_sources(source_dir, repository_name):
+    release_version = '%d.%d.%d' % (randint(0, 99999), randint(0, 99999),
+                                    randint(0, 99999))
+
+    zip_path = '%s.zip' % (path.basename(source_dir))
+    with ZipFile(zip_path, 'w') as zipper:
+        zipdir(source_dir, zipper)
+
+    upload_url = '%s/v2/%s/zipfile/%s' % (test_omps_host, quay_namespace, release_version)
+    headers = {'Authorization': quay_access_token}
+    files = {'file': open(zip_path, 'rb')}
+
+    res = requests.post(upload_url, files=files, headers=headers)
+    assert res.status_code == 200
+
+    ensure_application_release_removed_omps(repository_name, release_version)
+    ensure_zipfile_removed(zip_path)
+
+
+@pytest.mark.parametrize('source_dir,repository_name,release_version,error_message', [
+    ('tests/test_files/yaml_source_dir/invalid_yamls_without_package',
+     'oneagent',
+     '0.0.1',
+     'Could not find packageName in manifests.'),
+    ('tests/test_files/yaml_source_dir/invalid_yamls_multiple_packages',
+     'oneagent',
+     '0.0.1',
+     'Only 1 package is expected to exist in source root folder.'),
+])
+def test_push_invalid_sources(source_dir, repository_name,
+                              release_version, error_message):
+    zip_path = '%s.zip' % (path.basename(source_dir))
+    with ZipFile(zip_path, 'w') as zipper:
+        zipdir(source_dir, zipper)
+
+    upload_url = '%s/v2/%s/zipfile/%s' % (test_omps_host, quay_namespace, release_version)
+    headers = {'Authorization': quay_access_token}
+    files = {'file': open(zip_path, 'rb')}
+
+    res = requests.post(upload_url, files=files, headers=headers)
+    assert res.status_code != 200
+    message = res.json()['message']
+    assert error_message in message
+
+    ensure_zipfile_removed(zip_path)
+
+
+def zipdir(dir, zipf):
+    for root, dirs, files in walk(dir):
+        for file in files:
+            src_path = path.join(root, file)
+            dst_path = path.relpath(src_path, dir)
+            zipf.write(src_path, dst_path)
+
+
+def ensure_application_release_removed_omps(repository_name, release_version):
+    delete_url = '%s/v2/%s/%s/%s' % (test_omps_host, quay_namespace,
+                                     repository_name, release_version)
+    headers = {'Authorization': quay_access_token}
+
+    res = requests.delete(delete_url, headers=headers)
+    assert res.status_code == 200
+
+
+def ensure_zipfile_removed(zip_path):
+    assert remove(zip_path) is None

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -55,8 +55,7 @@ def ensure_application_release_removed(repository_name, release_version):
     ('tests/test_files/yaml_source_dir/valid_yamls_with_single_crd',
      'wrong-repo-name',
      '0.0.1',
-     'ERROR:operatorcourier.validate:'
-     'The packageName (oneagent) in bundle does not match '
+     'ERROR: The packageName (oneagent) in bundle does not match '
      'repository name (wrong-repo-name) provided as command line argument.'),
 ])
 def test_push_invalid_sources(source_dir, repository_name,
@@ -71,4 +70,5 @@ def test_push_invalid_sources(source_dir, repository_name,
     assert exit_code != 0
 
     outputs = process.stdout.read().decode('utf-8')
+    print(outputs)
     assert error_message in outputs

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -70,5 +70,4 @@ def test_push_invalid_sources(source_dir, repository_name,
     assert exit_code != 0
 
     outputs = process.stdout.read().decode('utf-8')
-    print(outputs)
     assert error_message in outputs

--- a/tests/test_files/omps_config/config.py
+++ b/tests/test_files/omps_config/config.py
@@ -1,0 +1,9 @@
+class ProdConfig:
+    LOG_LEVEL = "DEBUG"
+    LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+    REQUEST_TIMEOUT = 30
+
+    DEFAULT_RELEASE_VERSION = "0.0.1"
+    ORGANIZATIONS = {
+        "operator-manifests": {}
+    }

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,22 @@ envlist = py36,py37,flake8
 deps = .[test]
 commands =
     pytest --ignore=tests/integration --cov=operatorcourier {posargs}
-    ./run_integration_tests.sh
+    pytest tests/integration/test_verify.py
 
 passenv =
     TRAVIS_*
+    QUAY_NAMESPACE
+    QUAY_ACCESS_TOKEN
+
+[testenv:integration]
+deps = .[test]
+commands =
+    pytest tests/integration/test_verify.py
+    pytest tests/integration/test_push.py
+    pytest tests/integration/test_omps.py
+
+passenv =
+    OMPS_HOST
     QUAY_NAMESPACE
     QUAY_ACCESS_TOKEN
 


### PR DESCRIPTION
**Description of changes:**
* tox.ini: add integration env for push/omps tests
* omps-integration.Dockerfile: defines a container to run omps integration tests
* tests/: code and config for omps integration tests
* run_integration_tests.sh: runs integration tests. Useful for prow CI

**Motivation for changes:** operator-courier is an [integral part](https://github.com/release-engineering/operators-manifests-push-service/blob/v8.2/omps/quay.py#L279-L282) of manifest verification and pushing to quay.io in OMPS. Every PR can potentially break OMPS, so the desired changes to operator-courier in a PR should be integrated into and tested with the latest OMPS.

Travis CI tests will continue to function as before. These changes are intended to be used in OpenShift CI.

/cc @gallettilance @shawn-hurley @kevinrizza 
