### PR TITLE
set up operator-courier for prow CI integration tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Operator Courier is currently supported on Python 3.6 and above.
   ```bash
   $ pip3 install operator-courier==2.0.1
   ```
-    
+
 - To upgrade an existing operator-courier release:
 
   ```bash
@@ -91,29 +91,50 @@ def main():
 ```
 
 ## Building and running the tool locally with pip
+
 ```bash
 $ pip3 install --user .
-
 $ operator-courier
 ```
 
+## Building the docker image
+
+```sh
+$ docker build -f Dockerfile -t $TAG
+$ docker run $TAG operator-courier
+```
+
+For further details, please see the [contribution guide](docs/contributing.md).
+
 ## Testing
 
-### Running the tests
+### Unit tests
 
 [Install tox](https://tox.readthedocs.io/en/latest/install.html) and run:
 
-```bash 
+```bash
 $ tox
 ```
 
 This will run the tests with several versions of Python 3, measure coverage,
 and run flake8 for code linting.
 
-## Building the docker image
-```
-docker build Dockerfile -t $TAG
-docker run $TAG operator-courier
+### Integration tests
+
+Before running integration tests, you must have write access credentials to a [quay.io](https://quay.io) namespace. See the [authentication](#authentication) section for more information.
+
+First, build the integration docker image:
+
+```sh
+$ docker build -f integration.Dockerfile -t operator-courier-integration .
 ```
 
-For further details, please see the [contribution guide](docs/contributing.md).
+Then run the tests inside a container:
+
+```sh
+$ docker run \
+  -e QUAY_NAMESPACE="$QUAY_NAMESPACE" \
+  -e QUAY_ACCESS_TOKEN="$QUAY_ACCESS_TOKEN" \
+  operator-courier-integration:latest \
+  tox -e integration
+```

--- a/integration.Dockerfile
+++ b/integration.Dockerfile
@@ -1,0 +1,6 @@
+FROM operator-courier-base:latest
+
+RUN pip3 install tox coveralls
+
+WORKDIR /src
+COPY . .

--- a/run_integration_tests.sh
+++ b/run_integration_tests.sh
@@ -1,5 +1,0 @@
-#!/usr/bin/env bash
-
-echo "Running integration tests triggered by $TRAVIS_EVENT_TYPE..."
-
-pytest tests/integration/test_verify.py

--- a/tests/integration/test_push.py
+++ b/tests/integration/test_push.py
@@ -55,8 +55,7 @@ def ensure_application_release_removed(repository_name, release_version):
     ('tests/test_files/yaml_source_dir/valid_yamls_with_single_crd',
      'wrong-repo-name',
      '0.0.1',
-     'ERROR:operatorcourier.validate:'
-     'The packageName (oneagent) in bundle does not match '
+     'ERROR: The packageName (oneagent) in bundle does not match '
      'repository name (wrong-repo-name) provided as command line argument.'),
 ])
 def test_push_invalid_sources(source_dir, repository_name,

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,21 @@ envlist = py36,py37,flake8
 deps = .[test]
 commands =
     pytest --ignore=tests/integration --cov=operatorcourier {posargs}
-    ./run_integration_tests.sh
+    pytest tests/integration/test_verify.py
 
 passenv =
     TRAVIS_*
+    QUAY_NAMESPACE
+    QUAY_ACCESS_TOKEN
+
+[testenv:integration]
+deps = .[test]
+skipsdist = true
+skip_install = true
+commands =
+    pytest -v tests/integration
+
+passenv =
     QUAY_NAMESPACE
     QUAY_ACCESS_TOKEN
 


### PR DESCRIPTION
ci/integration.Dockerfile: image containing integration test deps

tox.ini: add integration environment

Note: this does not set up operator-courier for OMPS integration tests, just sets up existing integration tests for Prow CI. OMPS tests to follow.

/cc @shawn-hurley @gallettilance @kevinrizza 