### PR TITLE
add OMPS integration test files for prow CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,13 +123,14 @@ and run flake8 for code linting.
 
 Before running integration tests, you must have write access credentials to a [quay.io](https://quay.io) namespace. See the [authentication](#authentication) section for more information.
 
-First, build the integration docker image:
+First, build the integration docker images:
 
 ```sh
-$ docker build -f integration.Dockerfile -t operator-courier-integration .
+$ docker build -f tests/integration/dockerfiles/integration-base.Dockerfile -t operator-courier-integration-base:latest .
+$ docker build -f tests/integration/dockerfiles/integration.Dockerfile -t operator-courier-integration:latest .
 ```
 
-Then run the tests inside a container:
+Then run the tests inside a container using your access credentials:
 
 ```sh
 $ docker run \

--- a/integration.Dockerfile
+++ b/integration.Dockerfile
@@ -1,6 +1,0 @@
-FROM operator-courier-base:latest
-
-RUN pip3 install tox coveralls
-
-WORKDIR /src
-COPY . .

--- a/tests/integration/dockerfiles/integration-base.Dockerfile
+++ b/tests/integration/dockerfiles/integration-base.Dockerfile
@@ -1,0 +1,8 @@
+FROM fedora:29
+
+RUN dnf install -y --setopt=install_weak_deps=False --best \
+    git \
+    python3-tox \
+    python3-coveralls \
+    && dnf -y clean all \
+    && rm -rf /tmp/*

--- a/tests/integration/dockerfiles/integration.Dockerfile
+++ b/tests/integration/dockerfiles/integration.Dockerfile
@@ -1,0 +1,5 @@
+FROM operator-courier-integration-base:latest
+
+WORKDIR /operator-courier
+COPY . .
+RUN pip3 install .


### PR DESCRIPTION
* tests/integration/dockerfiles: organize integration test Dockerfiles here

* tests/integration/dockerfiles/integration-base.Dockerfile: base image for integration tests. Contains git for prow CI checkout.

/cc @gallettilance @kevinrizza @shawn-hurley 