### PR TITLE
Validate version must be the first item of versions

### DIFF
--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -163,12 +163,16 @@ class ValidateCmd():
                 if "versions" in crd['spec']:
                     if "version" in crd['spec']:
                         if "name" in crd['spec']['versions'][0]:
-                            if crd['spec']['version'] != crd['spec']['versions'][0]['name']:
-                                self._log_error("crd spec.version must be the first element in crd spec.versions")
+                            if crd['spec']['version'] != \
+                                    crd['spec']['versions'][0]['name']:
+                                self._log_error("crd spec.version must be "
+                                                "the first element in crd spec.versions")
                                 valid = False
                         else:
-                            if crd['spec']['version'] != crd['spec']['versions'][0]:
-                                self._log_error("crd spec.version must be the first element in crd spec.versions")
+                            if crd['spec']['version'] != \
+                                    crd['spec']['versions'][0]:
+                                self._log_error("crd spec.version must be "
+                                                "the first element in crd spec.versions")
                                 valid = False
 
         return valid

--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -160,6 +160,16 @@ class ValidateCmd():
                     if "version" not in crd['spec']:
                         self._log_error("crd spec.version or spec.versions not defined")
                         valid = False
+                if "versions" in crd['spec']:
+                    if "version" in crd['spec']:
+                        if "name" in crd['spec']['versions'][0]:
+                            if crd['spec']['version'] != crd['spec']['versions'][0]['name']:
+                                self._log_error("crd spec.version must be the first element in crd spec.versions")
+                                valid = False
+                        else:
+                            if crd['spec']['version'] != crd['spec']['versions'][0]:
+                                self._log_error("crd spec.version must be the first element in crd spec.versions")
+                                valid = False
 
         return valid
 

--- a/tests/test_files/bundles/verification/crdversions.invalid.bundle.yaml
+++ b/tests/test_files/bundles/verification/crdversions.invalid.bundle.yaml
@@ -340,6 +340,9 @@ data:
                 - registryNamespace
                 type: object
         version: v1alpha1
+        versions:
+          - v1beta1
+          - v1alpha1
   packages: |
     - channels:
       - currentCSV: marketplace-operator.v0.0.1

--- a/tests/test_files/bundles/verification/crdversions.valid.bundle.yaml
+++ b/tests/test_files/bundles/verification/crdversions.valid.bundle.yaml
@@ -341,6 +341,9 @@ data:
                 - registryNamespace
                 type: object
         version: v1alpha1
+        versions:
+        - v1alpha1
+        - v1beta1
   packages: |
     - channels:
       - currentCSV: marketplace-operator.v0.0.1


### PR DESCRIPTION
Signed-off-by: Chun Lin Yang <clyang@cn.ibm.com>
>
apiextensions.k8s.io/v1beta1, there was a `version` field instead of `versions`. The `version` field is deprecated and optional, but if it is not empty, it must match the first item in the `versions` field.

This PR is to validate this case.