### PR TITLE
Fixed missing space in linting

### DIFF
--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -228,7 +228,7 @@ class ValidateCmd():
                     pass
 
             if "owned" not in customresourcedefinitions:
-                self._log_error("spec.customresourcedefinitions.owned"
+                self._log_error("spec.customresourcedefinitions.owned "
                                 "not defined for csv")
                 return False
 


### PR DESCRIPTION
Fixed the following missing space during linting: 

```
ERROR: spec.customresourcedefinitions.ownednot defined for csv [0.0.5/zosmf-operator.v0.0.5.clusterserviceversion.yaml]
```

Should be: 

```
ERROR: spec.customresourcedefinitions.owned not defined for csv [0.0.5/zosmf-operator.v0.0.5.clusterserviceversion.yaml]
```