### PR TITLE
Correctly validate crd.spec.versions

### DIFF
--- a/tests/test_files/bundles/verification/crdversions.invalid.bundle.yaml
+++ b/tests/test_files/bundles/verification/crdversions.invalid.bundle.yaml
@@ -263,7 +263,9 @@ data:
                 - packages
                 type: object
         versions:
-        - v1beta1
+        - name: v1beta1
+          served: true
+          storage: true
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
       metadata:

--- a/tests/test_files/bundles/verification/crdversions.valid.bundle.yaml
+++ b/tests/test_files/bundles/verification/crdversions.valid.bundle.yaml
@@ -263,8 +263,12 @@ data:
                 - packages
                 type: object
         versions:
-        - v1alpha1
-        - v1beta1
+        - name: v1beta1
+          served: true
+          storage: true
+        - name: v1alpha1
+          served: true
+          storage: false
     - apiVersion: apiextensions.k8s.io/v1beta1
       kind: CustomResourceDefinition
       metadata:


### PR DESCRIPTION
Correctly validate crd.spec.versions

crd.spec.version got deprecated for crd.spec.versions
but in this case we are going to access a list of
dictionaries where the relevant value
is in the name field.

Fix all the validations on spec.versions and add
additional validations.

Fix also its test.

Signed-off-by: Simone Tiraboschi stirabos@redhat.com

Fixes: #188
