### PR TITLE
Add category "Drivers and Plugins" in validate.py

### DIFF
--- a/operatorcourier/validate.py
+++ b/operatorcourier/validate.py
@@ -634,6 +634,7 @@ class ValidateCmd():
                 "Cloud Provider",
                 "Developer Tools",
                 "Database",
+                "Drivers and Plugins", 
                 "Integration & Delivery",
                 "Logging & Tracing",
                 "Monitoring",


### PR DESCRIPTION
Proposing addition of category "Drivers and Plugins". This category was previously valid in https://github.com/operator-framework/community-operators/blob/master/categories.json (this is now archived).